### PR TITLE
Click on item bar anywhere to expand it

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -95,7 +95,7 @@ $("#feedly").on("click", "#btn-feeds", function () {
     renderFeeds();
 });
 
-$("#popup-content").on("click", ".show-content", function () {
+$("#popup-content").on("click", ".item", function () {
     var $this = $(this);
     var feed = $this.closest(".item");
     var contentContainer = feed.find(".content");
@@ -124,6 +124,10 @@ $("#popup-content").on("click", ".show-content", function () {
             setPopupExpand(false);
         }
     });
+});
+
+$("#popup-content").on("click", ".blog-title", function (event) {
+  event.stopPropagation();
 });
 
 /* Manually feeds update */


### PR DESCRIPTION
Makes it much easier to view expanded feed contents in the popup by clicking anywhere on an empty space in the collapsed item bar. It's also kind of an intuitively expected behavior (various feed viewers do that for title-only list of feeds), so I propose to make it the default, even without an option to toggle it.