### PR TITLE
Changed New Feeds Wording

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -138,7 +138,7 @@
         "message": "Use secure connection (https)"
     },
     "YouHaveNewFeeds": {
-        "message": "You have $count$ new feeds",
+        "message": "You have $count$ new posts",
         "placeholders": {
             "count": {
                 "content": "$1",


### PR DESCRIPTION
The wording for when you have new articles in your feeds was incorrect. Previously it was "You have new feeds", which is incorrect as you do not have new feed but a new post/article. You have a new feed when you subscribe to a new RSS Feed.