### PR TITLE
Updated passing https settings to request wrapper

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -842,6 +842,7 @@ function readOptions(callback) {
 }
 
 function apiRequestWrapper(methodName, settings) {
+    settings.useSecureConnection = appGlobal.options.useSecureConnection;
     var onSuccess = settings.onSuccess;
     settings.onSuccess = function (response) {
         setActiveStatus();


### PR DESCRIPTION
Proposed solution for fixing https api issue (please check my comment titled "Https" on Chrome Web Store in Problems section)
https://chrome.google.com/webstore/detail/feedly-notifier/egikgfbhipinieabdmcpigejkaomgjgb/support?utm_source=chrome-ntp-icon