### PR TITLE
Use blog icon in notification

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,7 @@
         "tabs",
         "notifications",
         "webRequest",
-        "*://*.feedly.com/"
+        "<all_urls>"
     ],
     // @if BROWSER='chrome'
     "optional_permissions": ["background"],

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -248,7 +248,7 @@ function sendDesktopNotification(feeds) {
                 type: 'basic',
                 title: feeds[i].blog,
                 message: feeds[i].title,
-                iconUrl: appGlobal.icons.defaultBig
+                iconUrl: feeds[i].blogIcon
             });
 
             appGlobal.notifications[id] = feeds[i].url;


### PR DESCRIPTION
b8b688098bb4ccd9f2bf737a9df38eb849025d35 changed the notification icon
URL to always use the default Feedly icon. These changes fix that
behavior by using the favicon URL which was used in previous versions.

This required a change to the extensions permissions since the extension
now needs to access arbitrary URLs for downloading the images.