### PR TITLE
Add support for Notification Sound extension

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -138,6 +138,10 @@ readOptions(function () {
     //Write all options in chrome storage and initialize application
     writeOptions(initialize);
 });
+
+browser.notifications.onShown.addListener(() => {
+    browser.runtime.sendMessage("@notification-sound", "new-notification");
+});
 // @endif
 
 chrome.storage.onChanged.addListener(function (changes, areaName) {


### PR DESCRIPTION
Notification Sound (currently Firefox only) plays a user-defined sound whenever a notification is shown. Currently it requires extensions to tell it about notifications. This simple patch adds that notification, and should only be added to the Firefox version, from how I understand the build system.