### PR TITLE
add possibility to mark as read if no engagement

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -66,7 +66,7 @@
         "message": "Mark as read"
     },
     "MarkAsReadEngagement": {
-        "message": "Mark as read if no engagement"
+        "message": "Mark as read if engagement less than the configuration"
     },
     "MaxNotificationsCount": {
         "message": "Max notifications count at once"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -17,6 +17,9 @@
     "EnableBackgroundMode": {
         "message": "Enable background mode"
     },
+    "EngagementFilterLimit": {
+      "message": "Article to hide if engagement less than"
+    },
     "ExpandedPopupWidth": {
         "message": "Expanded popup width"
     },
@@ -139,6 +142,9 @@
     },
     "ShowDesktopNotifications": {
         "message": "Show desktop notifications"
+    },
+    "ShowEngagementFilter": {
+      "message": "Show button to filter by engagement"
     },
     "ShowFullFeedContent": {
         "message": "Show full content of article in the expanded feed (if possible)"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -62,6 +62,9 @@
     "MarkAsRead": {
         "message": "Mark as read"
     },
+    "MarkAsReadEngagement": {
+        "message": "Mark as read if no engagement"
+    },
     "MaxNotificationsCount": {
         "message": "Max notifications count at once"
     },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -69,7 +69,7 @@
     "message": "Marquer comme lu"
   },
   "MarkAsReadEngagement": {
-    "message": "Marquer comme lu si pas de popularité"
+    "message": "Marquer comme lu si popularité inférieur à la configuration"
   },
   "MaxNotificationsCount": {
     "message": "Nombre maximum de notifications simultanées"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -17,6 +17,9 @@
   "EnableBackgroundMode": {
     "message": "Activer le mode en arrière-plan"
   },
+  "EngagementFilterLimit": {
+    "message": "Article à cacher si popularité inférieur à"
+  },
   "ExpandedPopupWidth": {
     "message": "Largeur de la fenêtre étendue"
   },
@@ -139,6 +142,9 @@
   },
   "ShowDesktopNotifications": {
     "message": "Afficher les notifications de bureau"
+  },
+  "ShowEngagementFilter": {
+    "message": "Afficher le bouton pour filtrer par popularité"
   },
   "ShowFullFeedContent": {
     "message": "Afficher le contenu complet dans la vue développée (si possible)"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -65,6 +65,9 @@
   "MarkAsRead": {
     "message": "Marquer comme lu"
   },
+  "MarkAsReadEngagement": {
+    "message": "Marquer comme lu si pas de popularité"
+  },
   "MaxNotificationsCount": {
     "message": "Nombre maximum de notifications simultanées"
   },

--- a/src/options.html
+++ b/src/options.html
@@ -116,6 +116,12 @@
                     <fieldset data-enable-parent="isFiltersEnabled" id="categories">
                         <legend data-locale-value="Categories"></legend>
                     </fieldset>
+                    
+                    <label for="showEngagementFilter" class="label" data-locale-value="ShowEngagementFilter"></label>
+                    <input id="showEngagementFilter" type="checkbox" data-option-name="showEngagementFilter" /><br>
+                    
+                    <label for="engagementFilterLimit" class="label" data-locale-value="EngagementFilterLimit"></label>
+                    <input id="engagementFilterLimit" type="number" data-enable-parent="showEngagementFilter"  min="0" max="10000" data-option-name="engagementFilterLimit" /><br>
                 </div>
             </div>
             <button type="submit" id="save" data-locale-value="Save" class="button">Save</button>

--- a/src/popup.html
+++ b/src/popup.html
@@ -17,6 +17,7 @@
         <div id="popup-actions">
             <em class="glyphicon glyphicon-share" id="open-all-news"><div class="arrow-up"></div><span></span></em>
             <em class="glyphicon glyphicon-ok" id="mark-all-read"><div class="arrow-up"></div><span></span></em>
+            <em class="glyphicon glyphicon-filter" id="mark-read-engagement"><div class="arrow-up"></div><span></span></em>
             <em class="glyphicon glyphicon-refresh icon-refresh" id="update-feeds"><div class="arrow-up"></div><span></span></em>
             <em class="glyphicon glyphicon-share icon-unsaved" id="open-unsaved-all-news"><div class="arrow-up"></div><span></span></em>
         </div>

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -33,6 +33,7 @@ var appGlobal = {
         expandFeeds: false,
         isFiltersEnabled: false,
         showEngagementFilter: false,
+        engagementFilterLimit: 0,
         openFeedsInSameTab: false,
         openFeedsInBackground: true,
         filters: [],

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -32,6 +32,7 @@ var appGlobal = {
         useSecureConnection: true,
         expandFeeds: false,
         isFiltersEnabled: false,
+        showEngagementFilter: false,
         openFeedsInSameTab: false,
         openFeedsInBackground: true,
         filters: [],

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -301,7 +301,8 @@ function markAllAsRead() {
 function markAsReadEngagement() {
     var feedIds = [];
     $(".item:visible").each(function (key, value) {
-        if($(value).find("span.engagement").length == 0) {
+        var engagement = $(value).find("span.engagement").text() || 0; //default value if no engagement: 0
+        if(engagement <= popupGlobal.backgroundPage.appGlobal.options.engagementFilterLimit) {
             feedIds.push($(value).data("id"));
         }
     });
@@ -370,8 +371,11 @@ function showFeeds() {
     $("#feedly").show().find("#popup-actions").show().children().show();
     $(".mark-read").attr("title", chrome.i18n.getMessage("MarkAsRead"));
     $(".show-content").attr("title", chrome.i18n.getMessage("More"));
-    $("#feedly").show().find("#popup-actions").show().children().filter(".icon-unsaved").hide();
+    $("#feedly").show().find("#popup-actions").show().children().filter(".icon-unsaved, #mark-read-engagement").hide();
 
+    if (popupGlobal.backgroundPage.appGlobal.options.showEngagementFilter) {
+        $("#mark-read-engagement").show();
+    }
 }
 
 function showSavedFeeds() {

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -302,7 +302,7 @@ function markAsReadEngagement() {
     var feedIds = [];
     $(".item:visible").each(function (key, value) {
         var engagement = $(value).find("span.engagement").text() || 0; //default value if no engagement: 0
-        if(engagement <= popupGlobal.backgroundPage.appGlobal.options.engagementFilterLimit) {
+        if(engagement < popupGlobal.backgroundPage.appGlobal.options.engagementFilterLimit) {
             feedIds.push($(value).data("id"));
         }
     });

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -10,6 +10,7 @@ $(document).ready(function () {
     $("#feed, #feed-saved").css("font-size", popupGlobal.backgroundPage.appGlobal.options.popupFontSize / 100 + "em");
     $("#website").text(chrome.i18n.getMessage("FeedlyWebsite"));
     $("#mark-all-read>span").text(chrome.i18n.getMessage("MarkAllAsRead"));
+    $("#mark-read-engagement>span").text(chrome.i18n.getMessage("MarkAsReadEngagement"));
     $("#update-feeds>span").text(chrome.i18n.getMessage("UpdateFeeds"));
     $("#open-all-news>span").text(chrome.i18n.getMessage("OpenAllFeeds"));
     $("#open-unsaved-all-news>span").text(chrome.i18n.getMessage("OpenAllSavedFeeds"));
@@ -59,6 +60,8 @@ $("#feed, #feed-saved").on("mousedown", "a", function (event) {
 });
 
 $("#popup-content").on("click", "#mark-all-read", markAllAsRead);
+
+$("#popup-content").on("click", "#mark-read-engagement", markAsReadEngagement);
 
 $("#popup-content").on("click", "#open-all-news", function () {
     $("#feed").find("a.title[data-link]").filter(":visible").each(function (key, value) {
@@ -291,6 +294,16 @@ function markAllAsRead() {
     var feedIds = [];
     $(".item:visible").each(function (key, value) {
         feedIds.push($(value).data("id"));
+    });
+    markAsRead(feedIds);
+}
+
+function markAsReadEngagement() {
+    var feedIds = [];
+    $(".item:visible").each(function (key, value) {
+        if($(value).find("span.engagement").length == 0) {
+            feedIds.push($(value).data("id"));
+        }
     });
     markAsRead(feedIds);
 }


### PR DESCRIPTION
After my comment here :
https://github.com/olsh/Feedly-Notifier/issues/95#issuecomment-388854980

I did the PR that mark as read at command for the current queue if there is no engagement.

Maybe we can add into the option a cursor for the minimum engagement before mark as read ? like less than 1000 engagement ?