### PR TITLE
Upgrade BPP to v2

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -27,6 +27,6 @@ jobs:
             - name: Browser Plugin Publish
               env:
                   PUPPETEER_EXECUTABLE_PATH: /opt/hostedtoolcache/chromium/latest/x64/chrome
-              uses: plasmo-corp/bpp@v1
+              uses: PlasmoHQ/bpp@v2
               with:
                   keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Upgrades the Browser Plugin Publish Github action to v2. We also renamed our organization which is why that's different now!

Heads up the schema's changed a bit.

Here's an updated representation: https://raw.githubusercontent.com/plasmo-corp/bpp/v2/keys.schema.json
Here's an example: https://github.com/PlasmoHQ/bpp/blob/main/keys.template.json

