### PR TITLE
Update core.js - Badge counter >999

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -447,7 +447,12 @@ function updateSavedFeeds() {
 /* Sets badge counter if unread feeds more than zero */
 function setBadgeCounter(unreadFeedsCount) {
     if (appGlobal.options.showCounter) {
-        chrome.browserAction.setBadgeText({ text: String(+unreadFeedsCount > 0 ? (+unreadFeedsCount >= 1000 ? "1k+" : unreadFeedsCount) : "")});
+        const unreadFeedsCountNumber = +unreadFeedsCount;
+        if (unreadFeedsCountNumber > 999) {
+            const thousands = Math.floor(unreadFeedsCountNumber / 1000);
+            unreadFeedsCount = thousands + "k+";
+        }
+        chrome.browserAction.setBadgeText({ text: String(unreadFeedsCountNumber > 0 ? unreadFeedsCount : "")});
     } else {
         chrome.browserAction.setBadgeText({ text: ""});
     }

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -447,7 +447,7 @@ function updateSavedFeeds() {
 /* Sets badge counter if unread feeds more than zero */
 function setBadgeCounter(unreadFeedsCount) {
     if (appGlobal.options.showCounter) {
-        chrome.browserAction.setBadgeText({ text: String(+unreadFeedsCount > 0 ? unreadFeedsCount : "")});
+        chrome.browserAction.setBadgeText({ text: String(+unreadFeedsCount > 0 ? (+unreadFeedsCount >= 1000 ? "1k+" : unreadFeedsCount) : "")});
     } else {
         chrome.browserAction.setBadgeText({ text: ""});
     }


### PR DESCRIPTION
Since the browser chrome is only wide enough for 3 chars, update the counter so that unreadfeeds count of >999 will show as "1k+"

My very first PR, hope I'm doing it right! Also not that familiar with javascript and I can't test this so..