### PR TITLE
Migrate extension to manifest v3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
 
     "name": "Feedly Notifier",
     "description": "__MSG_ExtensionDescription__",
@@ -9,16 +9,15 @@
         "storage",
         "tabs",
         "notifications",
-        "webRequest",
+        "webRequest"
+    ],
+    "host_permissions": [
         "*://*.feedly.com/"
     ],
-    "optional_permissions": [
-        // @if BROWSER='chrome'
-        "background",
-        // @endif
+    "optional_host_permissions": [
         "<all_urls>"
     ],
-    "browser_action": {
+    "action": {
         "default_icon": {
             "19": "/images/icon_inactive.png",
             "38": "/images/icon_inactive38.png"
@@ -45,16 +44,17 @@
     },
     // @endif
     "background": {
-        "scripts": [ "scripts/browser-polyfill.min.js", "scripts/feedly.api.js", "scripts/core.js"]
+        "service_worker": "scripts/background.js"
     },
     "icons": {
         "16": "/images/icon16.png",
         "48": "/images/icon48.png",
         "128": "/images/icon128.png"
     },
-    "web_accessible_resources": [
-        "/images/icon128.png"
-    ],
+    "web_accessible_resources": [{
+        "resources": ["/images/icon128.png", "sound/*.mp3"],
+        "matches": ["<all_urls>"]
+    }],
     // @if BROWSER!='firefox'
     "minimum_chrome_version": "70",
     // @endif

--- a/src/offscreen.html
+++ b/src/offscreen.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+</head>
+<body>
+<script src="scripts/offscreen.js"></script>
+</body>
+</html>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -1,0 +1,19 @@
+importScripts('browser-polyfill.min.js', 'feedly.api.js', 'core.js');
+
+async function ensureOffscreen() {
+    if (chrome.offscreen && !(await chrome.offscreen.hasDocument())) {
+        await chrome.offscreen.createDocument({
+            url: 'offscreen.html',
+            reasons: [chrome.offscreen.Reason.AUDIO_PLAYBACK],
+            justification: 'play notification sounds'
+        });
+    }
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg && msg.type === 'playSound') {
+        ensureOffscreen().then(() => {
+            chrome.runtime.sendMessage({offscreen: 'playSound', url: msg.url, volume: msg.volume});
+        });
+    }
+});

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -387,9 +387,11 @@ function removeFeedFromCache(feedId) {
 
 /* Plays alert sound */
 function playSound(){
-    var audio = new Audio(appGlobal.options.sound);
-    audio.volume = appGlobal.options.soundVolume;
-    audio.play();
+    chrome.runtime.sendMessage({
+        type: 'playSound',
+        url: chrome.runtime.getURL(appGlobal.options.sound),
+        volume: appGlobal.options.soundVolume
+    });
 }
 
 /* Returns only new feeds and set date of last feed

--- a/src/scripts/offscreen.js
+++ b/src/scripts/offscreen.js
@@ -1,0 +1,7 @@
+chrome.runtime.onMessage.addListener((msg) => {
+    if (msg && msg.offscreen === 'playSound') {
+        const audio = new Audio(msg.url);
+        audio.volume = msg.volume ?? 1;
+        audio.play();
+    }
+});


### PR DESCRIPTION
## Summary
- switch to manifest_version 3
- load background logic as a service worker
- route audio playback through an offscreen document

## Testing
- `yarn install` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c327170832f9bc7d1a609ba2dce