### PR TITLE
Fix login persistence issue 308

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -1051,8 +1051,11 @@ async function readOptions() {
     appGlobal.cachedFeeds = Array.isArray(cache.cachedFeeds) ? cache.cachedFeeds : [];
     appGlobal.cachedSavedFeeds = Array.isArray(cache.cachedSavedFeeds) ? cache.cachedSavedFeeds : [];
 
-    // If we have a token, treat as logged in until a request proves otherwise
+    // Explicitly set accessToken in API client and mark as logged in if token is present
+    appGlobal.feedlyApiClient.accessToken = appGlobal.options.accessToken;
+    // Treat presence of stored token as logged-in until proven otherwise by API request
     appGlobal.isLoggedIn = Boolean(appGlobal.options.accessToken);
+    console.debug("[Core] readOptions loaded, token present:", Boolean(appGlobal.options.accessToken));
 }
 
 async function apiRequestWrapper(methodName, settings) {


### PR DESCRIPTION
This pull request improves the reliability and accuracy of the login state management in the background script by ensuring that the access token and login status are consistently restored and checked after reading options from storage. It also enhances debugging and error handling during initialization.

Login state handling improvements:
* After reading options, the `accessToken` is explicitly restored to `appGlobal.feedlyApiClient`, and `appGlobal.isLoggedIn` is set based on the presence of the token to avoid stale or inconsistent login state. [[1]](diffhunk://#diff-8e7a7861049a3b1acccbfd3c265f70dd461fb8df6592afbdb119d539c48179f1L1054-R1058) [[2]](diffhunk://#diff-cb976ec4ee3b7f2d00211028c659d31d65168e92fae05da62212b69dd0663faeR14-R30)
* When responding to `"getState"` messages, the login state is now re-evaluated using both the presence of the access token and the current `isLoggedIn` flag, ensuring up-to-date and accurate status is reported.

Initialization and debugging enhancements:
* Added debug logging to track the initialization process, including the login state after reading options and upon completion or failure of initialization. [[1]](diffhunk://#diff-cb976ec4ee3b7f2d00211028c659d31d65168e92fae05da62212b69dd0663faeR14-R30) [[2]](diffhunk://#diff-8e7a7861049a3b1acccbfd3c265f70dd461fb8df6592afbdb119d539c48179f1L1054-R1058)
* Improved error handling during initialization by resetting the initialization promise if an error occurs, allowing retries on subsequent attempts.[Copilot is generating a summary...]