### PR TITLE
Fix login race condition when service worker wakes

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -192,6 +192,7 @@ browser.webRequest.onCompleted.addListener(async function (details) {
 }, {urls: ["*://*.feedly.com/v3/tags*global.saved*"]});
 
 browser.action.onClicked.addListener(async function () {
+    await ensureOptionsLoaded();
     if (appGlobal.isLoggedIn) {
         await openFeedlyTab();
         if(appGlobal.options.resetCounterOnClick){


### PR DESCRIPTION
## Summary

Related to #308 - Extension keeps asking for login

- Add `await ensureOptionsLoaded()` to the browser action click handler to ensure login state is loaded from storage before checking `isLoggedIn`

### Root Cause

When the Manifest V3 service worker becomes inactive and wakes on user click, there's a race condition:
1. `importScripts()` loads core.js and registers the click handler
2. `ensureInitialized()` starts async but doesn't block
3. Click event fires before initialization completes
4. `isLoggedIn` is still `false` (initial value) → redirects to login

This only affected users with "Open Feedly website directly" enabled, and depended on system timing (slow storage = bug appears).

### Solution

Add `await ensureOptionsLoaded()` at the start of the click handler, matching the pattern already used by the alarm handler.

## Test plan

- [x] Added artificial delay to reproduce the race condition
- [x] Verified bug reproduction: click shows login page
- [x] Applied fix
- [x] Verified fix works: click opens Feedly directly
- [x] Removed artificial delay