### PR TITLE
Increase maximum popup width from 750px to 800px

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -67,10 +67,10 @@
                 <input id="popupFontSize" type="number" data-disable-parent="openSiteOnIconClick" min="70" max="150" data-option-name="popupFontSize" /><br>
 
                 <label for="popupWidth" class="label" data-locale-value="PopupWidth"></label>
-                <input id="popupWidth" type="number" data-disable-parent="openSiteOnIconClick" min="380" max="750" data-option-name="popupWidth" /><br>
+                <input id="popupWidth" type="number" data-disable-parent="openSiteOnIconClick" min="380" max="800" data-option-name="popupWidth" /><br>
 
                 <label for="expandedPopupWidth" class="label" data-locale-value="ExpandedPopupWidth"></label>
-                <input id="expandedPopupWidth" type="number" data-disable-parent="openSiteOnIconClick" min="380" max="750" data-option-name="expandedPopupWidth" /><br>
+                <input id="expandedPopupWidth" type="number" data-disable-parent="openSiteOnIconClick" min="380" max="800" data-option-name="expandedPopupWidth" /><br>
 
                 <label for="showFullFeedContent" class="label" data-locale-value="ShowFullFeedContent"></label>
                 <input id="showFullFeedContent" type="checkbox" data-disable-parent="openSiteOnIconClick" data-option-name="showFullFeedContent" /><br>

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -61,7 +61,7 @@ var appGlobal = {
             this._updateInterval = value;
         },
         get popupWidth() {
-            let maxValue = 750;
+            let maxValue = 800;
             let minValue = 380;
             if (this._popupWidth > maxValue ) {
                 return maxValue;
@@ -75,7 +75,7 @@ var appGlobal = {
             this._popupWidth = value;
         },
         get expandedPopupWidth() {
-            let maxValue = 750;
+            let maxValue = 800;
             let minValue = 380;
             if (this._expandedPopupWidth > maxValue ) {
                 return maxValue;


### PR DESCRIPTION
## Summary

- Increases the maximum allowed popup width from 750px to 800px (the browser-enforced maximum)
- Updates both `popupWidth` and `expandedPopupWidth` settings

## Browser Limits Research

All major browsers enforce a hardcoded 800x600px maximum for extension popups:
- Chrome/Edge: 800px max (Chromium source: `kMaxSize = {800, 600}`)
- Firefox: 800px max (since Firefox 60)

## Changes

- `src/scripts/core.js`: Updated `maxValue` in both `popupWidth` and `expandedPopupWidth` getters
- `src/options.html`: Updated `max` attribute on both width input fields

Closes #240