### PR TITLE
Fix sync article read status with Feedly website

### DIFF
--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -181,7 +181,7 @@ browser.webRequest.onCompleted.addListener(async function (details) {
         updateFeeds();
         appGlobal.getUserSubscriptionsPromise = null;
     }
-}, {urls: ["*://*.feedly.com/v3/subscriptions*", "*://*.feedly.com/v3/markers?*ct=feedly.desktop*"]});
+}, {urls: ["*://*.feedly.com/v3/subscriptions*", "*://*.feedly.com/v3/markers*"]});
 
 /* Listener for adding or removing saved feeds */
 browser.webRequest.onCompleted.addListener(async function (details) {


### PR DESCRIPTION
## Summary
- Broadens the URL pattern for the webRequest listener to catch all `/v3/markers` API calls
- Previously the pattern `*://*.feedly.com/v3/markers?*ct=feedly.desktop*` was too restrictive and missed marker requests from the Feedly web app

Fixes #329