### PR TITLE
Fix: popup width not working in Vivaldi browser (issue #328)

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -491,7 +491,14 @@ function setPopupWidth(expanded) {
             ? options.expandedPopupWidth
             : options.popupWidth;
 
+        // Set width on feed containers
         $("#feed, #feed-saved, #feed-empty, #loading").width(width);
+        // Also set width on the popup content container so it respects the user's width setting
+        // (it only had min-width before, which doesn't constrain content in Vivaldi's popup panel)
+        $("#popup-content").width(width);
+        // In Vivaldi's popup panel, the root element's width constrains the entire viewport.
+        // Set it directly to ensure the user's width preference is respected.
+        document.documentElement.style.width = width + "px";
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes #328 — Popup width settings (min/max) are ignored in Vivaldi browser.

## Root Cause
setPopupWidth() only set .width() on the inner feed containers (#feed, #feed-saved, etc.) but did not set width on #popup-content (which only had min-width, not width). In Vivaldi's popup panel system, the root document element's width constrains the entire viewport, so without setting it explicitly, the popup panel ignores the user's width preference.

## Fix
Also set width on:
1. #popup-content — so the container itself respects the user's width setting
2. document.documentElement — so Vivaldi's popup panel constrains to the user's configured width

## Testing
- Width settings (popupWidth / expandedPopupWidth) now apply correctly in Vivaldi
- No regression for Chrome/Firefox/Opera since the added calls are additive