### PR TITLE
fix: the extension creates browser tabs using urls e... in popup.js

### DIFF
--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -59,6 +59,15 @@ $("#login").on("click", async function () {
     renderFeeds();
 });
 
+//Allow only safe URL schemes to prevent javascript:/data:/file: injection via feed content.
+function isSafeUrl(url) {
+    try {
+        return ["http:", "https:"].includes(new URL(url, location.href).protocol);
+    } catch {
+        return false;
+    }
+}
+
 //using "mousedown" instead of "click" event to process middle button click.
 $("#feed, #feed-saved").on("mousedown", "a", async function (event) {
     var link = $(this);
@@ -66,6 +75,10 @@ $("#feed, #feed-saved").on("mousedown", "a", async function (event) {
         var isActiveTab = !(event.ctrlKey || event.which === 2) && !options.openFeedsInBackground;
         var isFeed = link.hasClass("title") && $("#feed").is(":visible");
         var url = link.data("link");
+
+        if (!isSafeUrl(url)) {
+            return;
+        }
 
         if (isFeed && options.openFeedsInSameTab) {
             const resp = await bg.send("getFeedTabId");
@@ -104,7 +117,9 @@ $("#popup-content").on("click", "#open-all-news", async function () {
     const links = $("#feed").find("a.title[data-link]").filter(":visible");
     for (let i = 0; i < links.length; i++) {
         const news = $(links[i]);
-        await browser.tabs.create({url: news.data("link"), active: false });
+        if (isSafeUrl(news.data("link"))) {
+            await browser.tabs.create({url: news.data("link"), active: false });
+        }
     }
     if (options.markReadOnClick) {
         markAllAsRead();
@@ -115,7 +130,9 @@ $("#popup-content").on("click", "#open-unsaved-all-news", async function () {
     const links = $("#feed-saved").find("a.title[data-link]").filter(":visible");
     for (let i = 0; i < links.length; i++) {
         const news = $(links[i]);
-        await browser.tabs.create({url: news.data("link"), active: false });
+        if (isSafeUrl(news.data("link"))) {
+            await browser.tabs.create({url: news.data("link"), active: false });
+        }
     }
     markAllAsUnsaved();
 });


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/scripts/popup.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/scripts/popup.js:75` |
| **Assessment** | Likely exploitable |

**Description**: The extension creates browser tabs using URLs extracted from jQuery data attributes without validating the URL scheme. URLs from RSS feed content are passed directly to browser.tabs.create() and browser.tabs.update(), allowing javascript:, data:, file:, and other dangerous schemes to execute arbitrary code or redirect users to malicious sites.

## Evidence

**Exploitation scenario**: Attacker controls a malicious RSS feed containing javascript: URIs or data: URIs in article links.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `src/scripts/popup.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
