### PR TITLE
Use GitHub native auto-merge for Dependabot PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -32,7 +32,7 @@ jobs:
 
         steps:
             - id: metadata
-              uses: dependabot/fetch-metadata@v3.1.0
+              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,6 +4,8 @@ on:
         branches: ["master"]
     pull_request:
 
+permissions: {}
+
 jobs:
     test:
         strategy:
@@ -11,6 +13,10 @@ jobs:
             matrix:
                 browser: ["chrome", "opera", "firefox"]
         runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+
         steps:
             - uses: actions/checkout@v7
             - uses: actions/setup-node@v7

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,8 @@
 name: "Automerge"
-on: [push, pull_request]
+on:
+    push:
+        branches: ["master"]
+    pull_request:
 
 jobs:
     test:
@@ -20,7 +23,7 @@ jobs:
             - run: npx grunt build --clientId=${{ secrets.FEEDLY_CLIENT_ID }} --clientSecret=${{ secrets.FEEDLY_CLIENT_SECRET }} --browser=${{ matrix.browser }}
 
     automerge:
-        needs: test
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
         runs-on: ubuntu-latest
 
         permissions:
@@ -28,6 +31,13 @@ jobs:
             contents: write
 
         steps:
-            - uses: fastify/github-action-merge-dependabot@v3.15.0
+            - id: metadata
+              uses: dependabot/fetch-metadata@v3.1.0
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+              run: gh pr merge --auto --squash "$PR_URL"
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_URL: ${{ github.event.pull_request.html_url }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Feedly Notifier
 ===============
 
-[![Maintainability](https://api.codeclimate.com/v1/badges/cc043ddadb231bfaa48b/maintainability)](https://codeclimate.com/github/olsh/Feedly-Notifier/maintainability)
-[![Known Vulnerabilities](https://snyk.io/test/github/olsh/Feedly-Notifier/badge.svg)](https://snyk.io/test/github/olsh/Feedly-Notifier)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=olsh_Feedly-Notifier&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=olsh_Feedly-Notifier)
 ---
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/egikgfbhipinieabdmcpigejkaomgjgb)](https://chrome.google.com/webstore/detail/feedly-notifier/egikgfbhipinieabdmcpigejkaomgjgb)


### PR DESCRIPTION
Replaces `fastify/github-action-merge-dependabot` with GitHub's own auto-merge, and refreshes the README badges.

## Why

The action's only gate was `needs: test` inside this workflow, so checks from other workflows were invisible to it. On #382 it merged at `13:21:55Z` while CodeQL finished at `13:22:25Z` — the PR was merged 30 seconds before CodeQL reported, and Snyk passed before the merge only by timing luck.

With native auto-merge, GitHub holds the PR until every *required* check passes, so CodeQL and SonarCloud become real gates. The action's other features were unused anyway: `target` defaulted to `any`, no `exclude` list, and its auto-approval was pointless because `master` requires no reviews. Dropping it also removes third-party code holding `contents: write` on the default branch while pinned to a mutable tag.

## Changes

- `automerge` job now arms auto-merge (`gh pr merge --auto --squash`) instead of merging directly. It no longer needs `needs: test` — GitHub releases the PR when the required checks pass, and if a build fails the merge simply never happens.
- `dependabot/fetch-metadata` (GitHub-owned) blocks auto-merge of **semver-major** bumps, so a jquery or dompurify major now waits for review.
- `on:` limited to `push` on `master` + `pull_request`. Previously both events fired for Dependabot branches, running the 3-browser matrix twice per PR and logging a bogus `This action must be used in the context of a Pull Request` error on the push copy.
- README: Code Climate badge replaced with the SonarCloud quality gate; Snyk badge removed.

## Required follow-up (settings, not code)

This PR alone leaves nothing gating merges — auto-merge needs branch protection to wait on:

- enable **Allow auto-merge** on the repository;
- require these checks on `master` (with "up to date" **off**, to avoid Dependabot rebase churn): `test (chrome)`, `test (opera)`, `test (firefox)`, `Analyze (javascript)`, `SonarCloud Code Analysis`.

`enforce_admins` stays off, so direct pushes to `master` are unaffected.

Snyk's `security/snyk (olsh)` status comes from the Snyk GitHub App — removing the badge does not disconnect it; that has to be revoked in GitHub app installations or the Snyk dashboard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated repository automation to automatically squash-merge eligible non-major dependency updates.
  - Automated merging is limited to Dependabot pull requests, uses updated triggers and pinned tooling, and can proceed without waiting for tests to complete.
  - Improved workflow permission controls and restricted automated actions to the required repository access.

- **Documentation**
  - Replaced Code Climate and Snyk badges with a SonarCloud quality gate status badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->