### PR TITLE
Add unit and end-to-end test suites

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,12 +21,43 @@ jobs:
             - uses: actions/checkout@v7
             - uses: actions/setup-node@v7
               with:
-                  node-version: "20.x"
+                  node-version: "22.x"
                   cache: "npm"
 
             - run: npm install
             - run: npm run lint
+            - run: npm test
             - run: npx grunt build --clientId=${{ secrets.FEEDLY_CLIENT_ID }} --clientSecret=${{ secrets.FEEDLY_CLIENT_SECRET }} --browser=${{ matrix.browser }}
+
+    # Separate from the browser matrix: the extension only side-loads into
+    # Chromium, so running this three times would add no coverage. The build
+    # uses dummy credentials rather than the repository secrets, because the
+    # suite never exercises the real OAuth flow -- which also lets it run on
+    # pull requests from forks.
+    e2e:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+
+        steps:
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
+              with:
+                  node-version: "22.x"
+                  cache: "npm"
+
+            - run: npm install
+            - run: npx playwright install --with-deps chromium
+            - run: npm run build:e2e
+            - run: npm run test:e2e
+
+            - uses: actions/upload-artifact@v4
+              if: ${{ failure() }}
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 7
 
     automerge:
         if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -47,10 +47,12 @@ jobs:
                   node-version: "22.x"
                   cache: "npm"
 
-            # `npm ci` for reproducible installs, and the locally installed
-            # Playwright binary rather than `npx`, which would be free to fetch
-            # an unpinned package on demand.
-            - run: npm ci
+            # `npm ci --ignore-scripts` for a reproducible install that runs no
+            # dependency lifecycle scripts, and the locally installed Playwright
+            # binary rather than `npx`, which would be free to fetch an unpinned
+            # package on demand. Browsers are installed by the next step, so
+            # nothing here depends on a postinstall hook.
+            - run: npm ci --ignore-scripts
             - run: ./node_modules/.bin/playwright install --with-deps chromium
             - run: npm run build:e2e
             - run: npm run test:e2e

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,7 +18,11 @@ jobs:
             contents: read
 
         steps:
+            # No step here pushes or fetches, so the job has no use for a
+            # persisted token in .git/config.
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - uses: actions/setup-node@v7
               with:
                   node-version: "22.x"
@@ -41,7 +45,11 @@ jobs:
             contents: read
 
         steps:
+            # No step here pushes or fetches, so the job has no use for a
+            # persisted token in .git/config.
             - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
             - uses: actions/setup-node@v7
               with:
                   node-version: "22.x"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -47,8 +47,11 @@ jobs:
                   node-version: "22.x"
                   cache: "npm"
 
-            - run: npm install
-            - run: npx playwright install --with-deps chromium
+            # `npm ci` for reproducible installs, and the locally installed
+            # Playwright binary rather than `npx`, which would be free to fetch
+            # an unpinned package on demand.
+            - run: npm ci
+            - run: ./node_modules/.bin/playwright install --with-deps chromium
             - run: npm run build:e2e
             - run: npm run test:e2e
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ keys.json
 CLAUDE.md
 .claude/
 AGENTS.md
+
+# Test output
+test-results
+playwright-report
+blob-report
+coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,15 @@
 
 ## Project Structure & Module Organization
 
-Feedly Notifier is a browser extension for Chrome, Firefox, Opera, and Edge. Source files live in `src/`: JavaScript modules are under `src/scripts/`, extension pages are `popup.html` and `options.html`, and static resources are grouped into `styles/`, `images/`, `sound/`, and `_locales/`. Store-listing translations are maintained separately in `translations/store/`. Grunt generates unpacked extension files and release archives in `build/`; treat that directory as disposable output. The `e2e/` directory is reserved for end-to-end coverage but currently has no committed tests.
+Feedly Notifier is a browser extension for Chrome, Firefox, Opera, and Edge. Source files live in `src/`: JavaScript modules are under `src/scripts/`, extension pages are `popup.html` and `options.html`, and static resources are grouped into `styles/`, `images/`, `sound/`, and `_locales/`. Store-listing translations are maintained separately in `translations/store/`. Grunt generates unpacked extension files and release archives in `build/`; treat that directory as disposable output. Unit tests live in `test/` (Vitest) and end-to-end tests in `e2e/` (Playwright).
 
 ## Build, Test, and Development Commands
 
 - `npm ci` installs the exact dependency versions from `package-lock.json`.
 - `npm run lint` checks JavaScript with the repository's ESLint configuration.
 - `npm run lint:fix` applies safe, automatic lint fixes.
+- `npm test` runs the Vitest unit suite; `npm run test:watch` reruns on change and `npm run test:coverage` reports coverage.
+- `npm run build:e2e` produces the unpacked Chromium build the end-to-end suite loads, and `npm run test:e2e` runs it. Add `--headed` via `npm run test:e2e:headed` to watch it. Requires `npx playwright install chromium` once.
 - `npx grunt sandbox --clientId=<id> --clientSecret=<secret> --browser=chrome` creates an unpacked development build in `build/`. Supported browser values are `chrome`, `opera`, and `firefox`.
 - `npx grunt build --clientId=<id> --clientSecret=<secret> --browser=firefox` cleans, builds, and packages a browser-specific ZIP.
 
@@ -20,11 +22,20 @@ Follow `.editorconfig`: UTF-8, four-space indentation, final newlines, and no tr
 
 ## Testing Guidelines
 
-There is no automated test runner or coverage threshold yet. Before submitting, run `npm run lint`, build the affected browser target, and manually exercise authentication, feed refresh, badge counts, popup actions, and options persistence. For UI changes, verify both popup and options pages. Add future browser-flow tests under `e2e/` with behavior-focused names such as `popup-refresh.spec.js`.
+Run `npm run lint` and `npm test` before submitting; run `npm run test:e2e` as well when touching the popup, the options page, or the background worker. There is no coverage threshold.
+
+**Unit tests (`test/`, Vitest, `*.test.js`).** The source files export nothing -- they are classic browser globals joined at runtime by `importScripts`. `test/helpers/load-core.js` evaluates them in a fresh `vm` context per test and hands back `appGlobal` and the top-level functions; a fresh context is also how state is reset between tests. `test/helpers/browser-mock.js` stands in for the promise-based `browser.*` API, and `test/helpers/load-page.js` loads `popup.js` and `options.js` into jsdom for their pure logic. Two things to know before writing tests:
+
+- The `// @if BROWSER='...'` directives are comments, so raw `src/` runs *every* branch and the last one wins. The loaders preprocess source first (chrome by default); pass `targetBrowser` to assert another target. `test/preprocess.test.js` pins the in-house line-preserving preprocessor against the one Grunt uses.
+- The `vm` context has its own intrinsics, so `toBeInstanceOf(Array)` and `rejects.toThrow(Error)` do not hold. Assert structurally instead -- `toEqual`, `toMatchObject`, `toHaveProperty("status", 401)`. `Date` is injected from the host realm and does work.
+
+**End-to-end tests (`e2e/`, Playwright, `*.spec.js`, CommonJS).** These load the real built extension into Chromium. Playwright cannot intercept a service worker's own fetches, so the suite instead launches Chromium with `--host-resolver-rules` pointing `cloud.feedly.com` at a local mock (`e2e/fixtures/feedly-server.js`) and rewrites the built API URL from https to http; the shipped `*://*.feedly.com/*` permission already covers http, so the manifest is used as released. Every other host resolves to nothing, keeping the suite hermetic. Sign in with the `signIn` fixture rather than driving OAuth, and note it deliberately waits for the extension's install-time `writeOptions()` before seeding, or the seeded token is overwritten. Tests that would trigger the `<all_urls>` permission prompt cannot work here -- Playwright cannot accept it -- so that path is covered in `test/options.test.js` instead.
+
+Tests that deliberately pin existing incorrect behaviour are marked `KNOWN BUG` or `KNOWN BEHAVIOUR` with a file and line reference; treat those as a defect inventory, not as endorsements.
 
 ## Commit & Pull Request Guidelines
 
-Recent history uses short, imperative subjects such as `Sanitize feed content in all browsers`; dependency updates use `Bump <package> from <old> to <new> (#123)`. Keep commits focused and avoid signatures, attribution footers, or generated-by notices. Pull requests should explain the user-visible change, link relevant issues, list browsers manually tested, and include screenshots for UI changes. Confirm lint and a clean browser-specific build before requesting review.
+Recent history uses short, imperative subjects such as `Sanitize feed content in all browsers`; dependency updates use `Bump <package> from <old> to <new> (#123)`. Keep commits focused and avoid signatures, attribution footers, or generated-by notices. Pull requests should explain the user-visible change, link relevant issues, list browsers manually tested, and include screenshots for UI changes. Confirm lint, the unit suite, and a clean browser-specific build before requesting review.
 
 ## Security & Configuration
 

--- a/e2e/badge-counter.spec.js
+++ b/e2e/badge-counter.spec.js
@@ -11,12 +11,9 @@ test.describe("toolbar badge", () => {
         mockApi.setStream(GLOBAL_ALL, []);
     });
 
-    /** Waits for the badge to settle on a value. */
-    async function expectBadge(serviceWorker, expected) {
-        await expect.poll(
-            () => serviceWorker.evaluate(() => chrome.action.getBadgeText({})),
-            { message: `badge never became ${JSON.stringify(expected)}` }
-        ).toBe(expected);
+    /** Reads the toolbar badge out of the background worker. */
+    function badgeText(serviceWorker) {
+        return serviceWorker.evaluate(() => chrome.action.getBadgeText({}));
     }
 
     test("shows the unread count from the api", async ({ mockApi, signIn, serviceWorker }) => {
@@ -24,7 +21,9 @@ test.describe("toolbar badge", () => {
 
         await signIn();
 
-        await expectBadge(serviceWorker, "42");
+        await expect(async () => {
+            expect(await badgeText(serviceWorker)).toBe("42");
+        }).toPass();
     });
 
     test("abbreviates counts above 999", async ({ mockApi, signIn, serviceWorker }) => {
@@ -32,7 +31,9 @@ test.describe("toolbar badge", () => {
 
         await signIn();
 
-        await expectBadge(serviceWorker, "12k+");
+        await expect(async () => {
+            expect(await badgeText(serviceWorker)).toBe("12k+");
+        }).toPass();
     });
 
     test("stays empty when there is nothing unread", async ({ mockApi, signIn, serviceWorker }) => {
@@ -40,7 +41,9 @@ test.describe("toolbar badge", () => {
 
         await signIn();
 
-        await expectBadge(serviceWorker, "");
+        await expect(async () => {
+            expect(await badgeText(serviceWorker)).toBe("");
+        }).toPass();
     });
 
     test("stays empty when the counter is switched off", async ({ mockApi, signIn, serviceWorker }) => {
@@ -48,7 +51,9 @@ test.describe("toolbar badge", () => {
 
         await signIn({ showCounter: false });
 
-        await expectBadge(serviceWorker, "");
+        await expect(async () => {
+            expect(await badgeText(serviceWorker)).toBe("");
+        }).toPass();
     });
 
     test("ignores counts for streams the user is not looking at", async ({ mockApi, signIn, serviceWorker }) => {
@@ -59,7 +64,9 @@ test.describe("toolbar badge", () => {
 
         await signIn();
 
-        await expectBadge(serviceWorker, "7");
+        await expect(async () => {
+            expect(await badgeText(serviceWorker)).toBe("7");
+        }).toPass();
     });
 
     test("recovers by refreshing the token after a 401", async ({ mockApi, signIn, serviceWorker }) => {
@@ -69,9 +76,9 @@ test.describe("toolbar badge", () => {
         await signIn();
 
         // The wrapper refreshes the token and retries the original request.
-        await expect
-            .poll(() => mockApi.requestsTo("/v3/auth/token", "POST").length)
-            .toBeGreaterThan(0);
-        await expectBadge(serviceWorker, "5");
+        await expect(async () => {
+            expect(mockApi.requestsTo("/v3/auth/token", "POST").length).toBeGreaterThan(0);
+            expect(await badgeText(serviceWorker)).toBe("5");
+        }).toPass();
     });
 });

--- a/e2e/badge-counter.spec.js
+++ b/e2e/badge-counter.spec.js
@@ -1,0 +1,77 @@
+const { test, expect } = require("./fixtures/extension");
+const { SUBSCRIPTIONS, GLOBAL_ALL } = require("./fixtures/feed-items");
+
+/**
+ * Badge behaviour is pure background: no page involved, which makes these the
+ * fastest true integration tests in the suite.
+ */
+test.describe("toolbar badge", () => {
+    test.beforeEach(async ({ mockApi }) => {
+        mockApi.subscriptions = SUBSCRIPTIONS;
+        mockApi.setStream(GLOBAL_ALL, []);
+    });
+
+    /** Waits for the badge to settle on a value. */
+    async function expectBadge(serviceWorker, expected) {
+        await expect.poll(
+            () => serviceWorker.evaluate(() => chrome.action.getBadgeText({})),
+            { message: `badge never became ${JSON.stringify(expected)}` }
+        ).toBe(expected);
+    }
+
+    test("shows the unread count from the api", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 42 });
+
+        await signIn();
+
+        await expectBadge(serviceWorker, "42");
+    });
+
+    test("abbreviates counts above 999", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 12345 });
+
+        await signIn();
+
+        await expectBadge(serviceWorker, "12k+");
+    });
+
+    test("stays empty when there is nothing unread", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 0 });
+
+        await signIn();
+
+        await expectBadge(serviceWorker, "");
+    });
+
+    test("stays empty when the counter is switched off", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 99 });
+
+        await signIn({ showCounter: false });
+
+        await expectBadge(serviceWorker, "");
+    });
+
+    test("ignores counts for streams the user is not looking at", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({
+            [GLOBAL_ALL]: 7,
+            "feed/http://example-blog.com/rss": 1000
+        });
+
+        await signIn();
+
+        await expectBadge(serviceWorker, "7");
+    });
+
+    test("recovers by refreshing the token after a 401", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 5 });
+        mockApi.failNext("markers/counts", 401);
+
+        await signIn();
+
+        // The wrapper refreshes the token and retries the original request.
+        await expect
+            .poll(() => mockApi.requestsTo("/v3/auth/token", "POST").length)
+            .toBeGreaterThan(0);
+        await expectBadge(serviceWorker, "5");
+    });
+});

--- a/e2e/badge-counter.spec.js
+++ b/e2e/badge-counter.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require("./fixtures/extension");
+const { test, expect, RETRY } = require("./fixtures/extension");
 const { SUBSCRIPTIONS, GLOBAL_ALL } = require("./fixtures/feed-items");
 
 /**
@@ -23,7 +23,7 @@ test.describe("toolbar badge", () => {
 
         await expect(async () => {
             expect(await badgeText(serviceWorker)).toBe("42");
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("abbreviates counts above 999", async ({ mockApi, signIn, serviceWorker }) => {
@@ -33,7 +33,7 @@ test.describe("toolbar badge", () => {
 
         await expect(async () => {
             expect(await badgeText(serviceWorker)).toBe("12k+");
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("stays empty when there is nothing unread", async ({ mockApi, signIn, serviceWorker }) => {
@@ -43,7 +43,7 @@ test.describe("toolbar badge", () => {
 
         await expect(async () => {
             expect(await badgeText(serviceWorker)).toBe("");
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("stays empty when the counter is switched off", async ({ mockApi, signIn, serviceWorker }) => {
@@ -53,7 +53,7 @@ test.describe("toolbar badge", () => {
 
         await expect(async () => {
             expect(await badgeText(serviceWorker)).toBe("");
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("ignores counts for streams the user is not looking at", async ({ mockApi, signIn, serviceWorker }) => {
@@ -66,7 +66,7 @@ test.describe("toolbar badge", () => {
 
         await expect(async () => {
             expect(await badgeText(serviceWorker)).toBe("7");
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("recovers by refreshing the token after a 401", async ({ mockApi, signIn, serviceWorker }) => {
@@ -79,6 +79,6 @@ test.describe("toolbar badge", () => {
         await expect(async () => {
             expect(mockApi.requestsTo("/v3/auth/token", "POST").length).toBeGreaterThan(0);
             expect(await badgeText(serviceWorker)).toBe("5");
-        }).toPass();
+        }).toPass(RETRY);
     });
 });

--- a/e2e/extension-loads.spec.js
+++ b/e2e/extension-loads.spec.js
@@ -1,0 +1,70 @@
+const { test, expect } = require("./fixtures/extension");
+const { item, SUBSCRIPTIONS, GLOBAL_ALL } = require("./fixtures/feed-items");
+
+/**
+ * The smoke test for the whole harness. If this passes, the extension loads,
+ * the service worker runs, and the mock API is genuinely intercepting the
+ * worker's own fetches.
+ */
+test.describe("extension loading", () => {
+    test("registers a service worker with a valid MV3 manifest", async ({ serviceWorker, extensionId }) => {
+        expect(extensionId).toMatch(/^[a-z]{32}$/);
+
+        const manifest = await serviceWorker.evaluate(() => chrome.runtime.getManifest());
+
+        expect(manifest.manifest_version).toBe(3);
+        expect(manifest.name).toBe("Feedly Notifier");
+        expect(manifest.background.service_worker).toBe("scripts/background.js");
+    });
+
+    test("loads the core scripts into the worker", async ({ serviceWorker }) => {
+        const globals = await serviceWorker.evaluate(() => ({
+            hasAppGlobal: typeof globalThis.appGlobal === "object",
+            hasGetFeeds: typeof globalThis.getFeeds === "function",
+            hasApiClient: Boolean(globalThis.appGlobal && globalThis.appGlobal.feedlyApiClient)
+        }));
+
+        expect(globals).toEqual({ hasAppGlobal: true, hasGetFeeds: true, hasApiClient: true });
+    });
+
+    /*
+     * The load-bearing assertion for the e2e design: Playwright cannot route
+     * service-worker traffic, so interception is done at the network layer with
+     * --host-resolver-rules. This proves it reaches the worker's own fetches.
+     */
+    test("routes the worker's api calls to the mock server", async ({ serviceWorker, mockApi }) => {
+        const body = await serviceWorker.evaluate(async () => {
+            const response = await fetch("http://cloud.feedly.com/v3/profile");
+            return response.json();
+        });
+
+        expect(body).toMatchObject({ id: "e2e-user" });
+        expect(mockApi.requestsFor("/v3/profile")).toHaveLength(1);
+    });
+
+    test("starts signed out", async ({ serviceWorker }) => {
+        const isLoggedIn = await serviceWorker.evaluate(() => globalThis.appGlobal.isLoggedIn);
+
+        expect(isLoggedIn).toBe(false);
+    });
+
+    test("fetches feeds through the mock once signed in", async ({ mockApi, signIn }) => {
+        mockApi.subscriptions = SUBSCRIPTIONS;
+        mockApi.setStream(GLOBAL_ALL, [item("a"), item("b")]);
+
+        await signIn();
+
+        await expect.poll(() => mockApi.requestsFor("/contents").length).toBeGreaterThan(0);
+    });
+
+    test("opens the popup without console errors", async ({ popupPage, mockApi }) => {
+        mockApi.setStream(GLOBAL_ALL, []);
+        const errors = [];
+
+        const page = await popupPage();
+        page.on("pageerror", error => errors.push(error.message));
+        await page.waitForLoadState("domcontentloaded");
+
+        expect(errors).toEqual([]);
+    });
+});

--- a/e2e/extension-loads.spec.js
+++ b/e2e/extension-loads.spec.js
@@ -54,7 +54,9 @@ test.describe("extension loading", () => {
 
         await signIn();
 
-        await expect.poll(() => mockApi.requestsFor("/contents").length).toBeGreaterThan(0);
+        await expect(async () => {
+            expect(mockApi.requestsFor("/contents").length).toBeGreaterThan(0);
+        }).toPass();
     });
 
     test("opens the popup without console errors", async ({ popupPage, mockApi }) => {

--- a/e2e/extension-loads.spec.js
+++ b/e2e/extension-loads.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require("./fixtures/extension");
+const { test, expect, RETRY } = require("./fixtures/extension");
 const { item, SUBSCRIPTIONS, GLOBAL_ALL } = require("./fixtures/feed-items");
 
 /**
@@ -56,15 +56,17 @@ test.describe("extension loading", () => {
 
         await expect(async () => {
             expect(mockApi.requestsFor("/contents").length).toBeGreaterThan(0);
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("opens the popup without console errors", async ({ popupPage, mockApi }) => {
         mockApi.setStream(GLOBAL_ALL, []);
         const errors = [];
 
-        const page = await popupPage();
-        page.on("pageerror", error => errors.push(error.message));
+        // Registered before goto(), so errors thrown during navigation count.
+        const page = await popupPage("", target => {
+            target.on("pageerror", error => errors.push(error.message));
+        });
         await page.waitForLoadState("domcontentloaded");
 
         expect(errors).toEqual([]);

--- a/e2e/fixtures/extension.js
+++ b/e2e/fixtures/extension.js
@@ -29,7 +29,9 @@ function pointBuildAtMockServer() {
     }
 
     const source = fs.readFileSync(apiFile, "utf8");
-    const rewritten = source.replace("https://cloud.feedly.com/v3/", "http://cloud.feedly.com/v3/");
+    // Downgrading to plain HTTP is the point: it lets the loopback mock answer
+    // without a self-signed certificate. Test builds only, never shipped.
+    const rewritten = source.replace("https://cloud.feedly.com/v3/", "http://cloud.feedly.com/v3/"); // NOSONAR
 
     if (rewritten !== source) {
         fs.writeFileSync(apiFile, rewritten);

--- a/e2e/fixtures/extension.js
+++ b/e2e/fixtures/extension.js
@@ -1,0 +1,183 @@
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+
+const base = require("@playwright/test");
+
+const { FeedlyMockServer } = require("./feedly-server");
+const { USER_ID } = require("./feed-items");
+
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+const BUILD_DIR = path.join(PROJECT_ROOT, "build");
+
+/**
+ * Rewrites the API scheme in the built extension from https to http, so the
+ * plain-HTTP mock server can answer.
+ *
+ * Only the scheme changes -- the host stays cloud.feedly.com, which is what
+ * lets the shipped `*://*.feedly.com/*` host permission keep working and keeps
+ * the manifest untouched. `--host-resolver-rules` then sends that host to the
+ * mock. Idempotent, so repeated runs over one build are safe.
+ */
+function pointBuildAtMockServer() {
+    const apiFile = path.join(BUILD_DIR, "scripts", "feedly.api.js");
+
+    if (!fs.existsSync(apiFile)) {
+        throw new Error(
+            `Built extension not found at ${BUILD_DIR}. Run \`npm run build:e2e\` first.`
+        );
+    }
+
+    const source = fs.readFileSync(apiFile, "utf8");
+    const rewritten = source.replace("https://cloud.feedly.com/v3/", "http://cloud.feedly.com/v3/");
+
+    if (rewritten !== source) {
+        fs.writeFileSync(apiFile, rewritten);
+    }
+}
+
+const test = base.test.extend({
+    /** A mock Feedly API on an ephemeral port, reset for every test. */
+    mockApi: async ({}, use) => {
+        const server = new FeedlyMockServer();
+        await server.start();
+        await use(server);
+        await server.stop();
+    },
+
+    /**
+     * A persistent context with the unpacked extension loaded.
+     *
+     * Extensions require a persistent context and Playwright's bundled
+     * Chromium: Chrome and Edge have removed the side-loading flags. This does
+     * work headless, so CI needs no xvfb.
+     */
+    context: async ({ mockApi }, use) => {
+        pointBuildAtMockServer();
+
+        const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "feedly-notifier-e2e-"));
+        const context = await base.chromium.launchPersistentContext(userDataDir, {
+            channel: "chromium",
+            args: [
+                `--disable-extensions-except=${BUILD_DIR}`,
+                `--load-extension=${BUILD_DIR}`,
+                /*
+                 * Send the API host to the mock, and fail every other lookup so
+                 * the suite can never reach the real network. example-blog.com
+                 * is the host in the feed fixtures; pointing it at the mock too
+                 * means article tabs actually navigate, so their URLs stay
+                 * assertable instead of collapsing to chrome-error://.
+                 */
+                "--host-resolver-rules=" + [
+                    `MAP cloud.feedly.com 127.0.0.1:${mockApi.port}`,
+                    `MAP example-blog.com 127.0.0.1:${mockApi.port}`,
+                    "MAP * ~NOTFOUND",
+                    "EXCLUDE 127.0.0.1"
+                ].join(",")
+            ]
+        });
+
+        await use(context);
+        await context.close();
+        fs.rmSync(userDataDir, { recursive: true, force: true });
+    },
+
+    /** The extension's service worker, awaited into existence. */
+    serviceWorker: async ({ context }, use) => {
+        let [worker] = context.serviceWorkers();
+        if (!worker) {
+            worker = await context.waitForEvent("serviceworker");
+        }
+        await use(worker);
+    },
+
+    extensionId: async ({ serviceWorker }, use) => {
+        await use(serviceWorker.url().split("/")[2]);
+    },
+
+    /**
+     * Signs the extension in by seeding storage, then waits for the background
+     * to notice. Seeding accessToken fires storage.onChanged, which re-reads
+     * the options and restarts the schedule, so the extension starts calling
+     * the mock immediately -- prime `mockApi` before using this.
+     */
+    signIn: async ({ serviceWorker }, use) => {
+        const signIn = async (options = {}) => {
+            /*
+             * On a fresh profile the extension's runtime.onInstalled handler
+             * runs readOptions() then writeOptions(), which persists the whole
+             * default option set -- including an empty accessToken. Seeding
+             * before that lands gets silently overwritten, so wait for the
+             * defaults to appear first. `updateInterval` is only ever written by
+             * writeOptions(), which makes it a reliable sentinel.
+             */
+            await base.expect.poll(
+                () => serviceWorker.evaluate(async () => {
+                    const stored = await chrome.storage.sync.get("updateInterval");
+                    return stored.updateInterval !== undefined;
+                }),
+                { message: "extension never wrote its default options" }
+            ).toBe(true);
+
+            const written = await serviceWorker.evaluate(async (values) => {
+                await chrome.storage.local.set({ disableOptionsSync: false });
+
+                /*
+                 * chrome.storage.sync can also silently drop writes while its
+                 * backend starts up in a fresh profile: set() resolves, but a
+                 * following get() returns nothing. Write until it sticks.
+                 */
+                for (let attempt = 0; attempt < 20; attempt++) {
+                    await chrome.storage.sync.set(values);
+                    const stored = await chrome.storage.sync.get("accessToken");
+                    if (stored.accessToken === values.accessToken) {
+                        return true;
+                    }
+                    await new Promise(resolve => setTimeout(resolve, 100));
+                }
+                return false;
+            }, {
+                accessToken: "e2e-access-token",
+                refreshToken: "e2e-refresh-token",
+                feedlyUserId: USER_ID,
+                ...options
+            });
+
+            base.expect(written, "chrome.storage.sync never accepted the seeded options").toBe(true);
+
+            await base.expect.poll(
+                () => serviceWorker.evaluate(() => globalThis.appGlobal.options.accessToken),
+                { message: "background never picked up the seeded access token" }
+            ).toBe("e2e-access-token");
+        };
+
+        await use(signIn);
+    },
+
+    /** Opens the popup page the way the toolbar button would. */
+    popupPage: async ({ context, extensionId }, use) => {
+        const open = async (query = "") => {
+            const page = await context.newPage();
+            await page.goto(`chrome-extension://${extensionId}/popup.html${query}`);
+            return page;
+        };
+
+        await use(open);
+    },
+
+    /** Opens the options page. */
+    optionsPage: async ({ context, extensionId }, use) => {
+        const open = async () => {
+            const page = await context.newPage();
+            page.on("dialog", dialog => dialog.accept());
+            await page.goto(`chrome-extension://${extensionId}/options.html`);
+            return page;
+        };
+
+        await use(open);
+    }
+});
+
+const expect = base.expect;
+
+module.exports = { test, expect, BUILD_DIR, PROJECT_ROOT };

--- a/e2e/fixtures/extension.js
+++ b/e2e/fixtures/extension.js
@@ -156,10 +156,16 @@ const test = base.test.extend({
         await use(signIn);
     },
 
-    /** Opens the popup page the way the toolbar button would. */
+    /**
+     * Opens the popup page the way the toolbar button would.
+     *
+     * `beforeNavigate` runs against the blank page before goto(), which is the
+     * only way to observe events raised during navigation itself.
+     */
     popupPage: async ({ context, extensionId }, use) => {
-        const open = async (query = "") => {
+        const open = async (query = "", beforeNavigate) => {
             const page = await context.newPage();
+            beforeNavigate?.(page);
             await page.goto(`chrome-extension://${extensionId}/popup.html${query}`);
             return page;
         };
@@ -182,4 +188,11 @@ const test = base.test.extend({
 
 const expect = base.expect;
 
-module.exports = { test, expect, BUILD_DIR, PROJECT_ROOT };
+/*
+ * `toPass()` defaults to no timeout, so a failing condition would spin until the
+ * test's own 30s limit and report the timeout rather than the assertion. Give
+ * every retry loop the same budget as the other assertions.
+ */
+const RETRY = { timeout: 10000 };
+
+module.exports = { test, expect, RETRY, BUILD_DIR, PROJECT_ROOT };

--- a/e2e/fixtures/extension.js
+++ b/e2e/fixtures/extension.js
@@ -84,13 +84,41 @@ const test = base.test.extend({
         fs.rmSync(userDataDir, { recursive: true, force: true });
     },
 
-    /** The extension's service worker, awaited into existence. */
+    /**
+     * The extension's service worker.
+     *
+     * Exposed as a wrapper rather than the raw handle because MV3 recycles
+     * workers: a handle captured at the start of a test goes stale the moment
+     * Chrome restarts the worker, and every later evaluate() on it throws. That
+     * failure is invisible inside a toPass() loop, which just retries until its
+     * budget expires. So re-acquire the live worker on each call and retry once
+     * if it dies mid-evaluate.
+     */
     serviceWorker: async ({ context }, use) => {
-        let [worker] = context.serviceWorkers();
-        if (!worker) {
-            worker = await context.waitForEvent("serviceworker");
-        }
-        await use(worker);
+        const current = async () => {
+            const [worker] = context.serviceWorkers();
+            return worker || context.waitForEvent("serviceworker");
+        };
+
+        const initial = await current();
+        const isGone = (error) => /destroyed|closed|Target|Execution context/i.test(String(error));
+
+        await use({
+            // The extension id is fixed for the profile, so this stays valid.
+            url: () => initial.url(),
+            evaluate: async (fn, arg) => {
+                const worker = await current();
+                try {
+                    return await worker.evaluate(fn, arg);
+                } catch (error) {
+                    if (!isGone(error)) {
+                        throw error;
+                    }
+                    const restarted = await current();
+                    return restarted.evaluate(fn, arg);
+                }
+            }
+        });
     },
 
     extensionId: async ({ serviceWorker }, use) => {
@@ -173,12 +201,20 @@ const test = base.test.extend({
         await use(open);
     },
 
-    /** Opens the options page. */
+    /**
+     * Opens the options page and waits until it has finished populating.
+     *
+     * loadOptions() fills the form asynchronously after DOMContentLoaded, so a
+     * test that types into a control before that completes has its input
+     * overwritten by the stored value. options.js sets `optionsGlobal.loaded`
+     * once all three loaders resolve, which is the signal to wait on.
+     */
     optionsPage: async ({ context, extensionId }, use) => {
         const open = async () => {
             const page = await context.newPage();
             page.on("dialog", dialog => dialog.accept());
             await page.goto(`chrome-extension://${extensionId}/options.html`);
+            await page.waitForFunction(() => window.optionsGlobal && window.optionsGlobal.loaded === true);
             return page;
         };
 

--- a/e2e/fixtures/feed-items.js
+++ b/e2e/fixtures/feed-items.js
@@ -1,0 +1,38 @@
+/** Builders for the Feedly payloads the mock server serves. */
+
+const USER_ID = "e2e-user";
+const GLOBAL_ALL = `user/${USER_ID}/category/global.all`;
+const GLOBAL_SAVED = `user/${USER_ID}/tag/global.saved`;
+
+/** One entry in a stream response. */
+function item(id, overrides = {}) {
+    return {
+        id,
+        title: `Article ${id}`,
+        origin: {
+            htmlUrl: "http://example-blog.com",
+            streamId: "feed/http://example-blog.com/rss",
+            title: "Example Blog"
+        },
+        alternate: [{ href: `http://example-blog.com/posts/${id}` }],
+        summary: { content: `<p>Summary of article ${id}</p>`, direction: "ltr" },
+        crawled: Date.UTC(2024, 0, 15, 12, 0, 0),
+        engagement: 10,
+        engagementRate: 1,
+        categories: [{ id: `user/${USER_ID}/category/Tech`, label: "Tech" }],
+        ...overrides
+    };
+}
+
+/** An entry already tagged as saved. */
+function savedItem(id, overrides = {}) {
+    return item(id, { tags: [{ id: GLOBAL_SAVED }], ...overrides });
+}
+
+const SUBSCRIPTIONS = [{
+    id: "feed/http://example-blog.com/rss",
+    title: "Example Blog",
+    categories: [{ id: `user/${USER_ID}/category/Tech`, label: "Tech" }]
+}];
+
+module.exports = { item, savedItem, SUBSCRIPTIONS, USER_ID, GLOBAL_ALL, GLOBAL_SAVED };

--- a/e2e/fixtures/feed-items.js
+++ b/e2e/fixtures/feed-items.js
@@ -10,7 +10,8 @@ function item(id, overrides = {}) {
         id,
         title: `Article ${id}`,
         origin: {
-            htmlUrl: "http://example-blog.com",
+            // Plain HTTP so the loopback mock can serve the article tabs. NOSONAR
+            htmlUrl: "http://example-blog.com", // NOSONAR
             streamId: "feed/http://example-blog.com/rss",
             title: "Example Blog"
         },

--- a/e2e/fixtures/feed-items.js
+++ b/e2e/fixtures/feed-items.js
@@ -10,7 +10,7 @@ function item(id, overrides = {}) {
         id,
         title: `Article ${id}`,
         origin: {
-            // Plain HTTP so the loopback mock can serve the article tabs. NOSONAR
+            // Plain HTTP so the loopback mock can serve the article tabs.
             htmlUrl: "http://example-blog.com", // NOSONAR
             streamId: "feed/http://example-blog.com/rss",
             title: "Example Blog"

--- a/e2e/fixtures/feedly-server.js
+++ b/e2e/fixtures/feedly-server.js
@@ -13,11 +13,12 @@ const http = require("node:http");
  * manifest is used exactly as released.
  */
 class FeedlyMockServer {
+    server = null;
+    port = null;
+    /** Every request the extension made, for assertions. */
+    requests = [];
+
     constructor() {
-        this.server = null;
-        this.port = null;
-        /** Every request the extension made, for assertions. */
-        this.requests = [];
         this.reset();
     }
 
@@ -78,7 +79,10 @@ class FeedlyMockServer {
     }
 
     handle(request, response) {
-        const url = new URL(request.url, "http://cloud.feedly.com");
+        // Base for parsing only. Plain HTTP is deliberate: this mock stands in
+        // for the API over the loopback interface, avoiding a self-signed
+        // certificate. It never carries real traffic. NOSONAR
+        const url = new URL(request.url, "http://cloud.feedly.com"); // NOSONAR
         const chunks = [];
 
         request.on("data", chunk => chunks.push(chunk));

--- a/e2e/fixtures/feedly-server.js
+++ b/e2e/fixtures/feedly-server.js
@@ -81,7 +81,7 @@ class FeedlyMockServer {
     handle(request, response) {
         // Base for parsing only. Plain HTTP is deliberate: this mock stands in
         // for the API over the loopback interface, avoiding a self-signed
-        // certificate. It never carries real traffic. NOSONAR
+        // certificate. It never carries real traffic.
         const url = new URL(request.url, "http://cloud.feedly.com"); // NOSONAR
         const chunks = [];
 

--- a/e2e/fixtures/feedly-server.js
+++ b/e2e/fixtures/feedly-server.js
@@ -1,0 +1,179 @@
+const http = require("node:http");
+
+/**
+ * A stand-in for the Feedly v3 API.
+ *
+ * The extension's own requests come from its MV3 service worker, and Playwright
+ * cannot intercept those with `context.route()` -- service-worker traffic is
+ * invisible to it, and the documented workaround (`serviceWorkers: "block"`)
+ * would disable the extension entirely. So the browser is launched with
+ * `--host-resolver-rules` pointing cloud.feedly.com at this server instead, and
+ * the built extension has its API scheme rewritten from https to http. The
+ * shipped `*://*.feedly.com/*` host permission already covers http, so the
+ * manifest is used exactly as released.
+ */
+class FeedlyMockServer {
+    constructor() {
+        this.server = null;
+        this.port = null;
+        /** Every request the extension made, for assertions. */
+        this.requests = [];
+        this.reset();
+    }
+
+    /** Restores the default payloads and clears recorded traffic. */
+    reset() {
+        this.requests = [];
+        this.failures = new Map();
+        this.userId = "e2e-user";
+        this.accessToken = "e2e-access-token";
+        this.profile = { id: this.userId, email: "e2e@example.com", fullName: "E2E User" };
+        this.subscriptions = [];
+        this.categories = [];
+        this.unreadCounts = [];
+        /** Stream id (decoded) to the items it should return. */
+        this.streams = new Map();
+    }
+
+    /** Makes the next request to a matching path fail with `status`. */
+    failNext(pathFragment, status) {
+        this.failures.set(pathFragment, status);
+    }
+
+    setStream(streamId, items) {
+        this.streams.set(streamId, items);
+    }
+
+    setUnreadCounts(counts) {
+        this.unreadCounts = Object.entries(counts).map(([id, count]) => ({ id, count }));
+    }
+
+    /**
+     * Requests recorded so far whose path contains `fragment`.
+     * Substring matching, so "/v3/markers" also matches "/v3/markers/counts";
+     * use `requestsTo` when the distinction matters.
+     */
+    requestsFor(fragment) {
+        return this.requests.filter(request => request.path.includes(fragment));
+    }
+
+    /** Requests recorded so far for exactly this path, optionally by method. */
+    requestsTo(path, method) {
+        return this.requests.filter(request =>
+            request.path === path && (!method || request.method === method));
+    }
+
+    async start() {
+        this.server = http.createServer((request, response) => this.handle(request, response));
+        await new Promise(resolve => this.server.listen(0, "127.0.0.1", resolve));
+        this.port = this.server.address().port;
+        return this.port;
+    }
+
+    async stop() {
+        if (this.server) {
+            await new Promise(resolve => this.server.close(resolve));
+            this.server = null;
+        }
+    }
+
+    handle(request, response) {
+        const url = new URL(request.url, "http://cloud.feedly.com");
+        const chunks = [];
+
+        request.on("data", chunk => chunks.push(chunk));
+        request.on("end", () => {
+            const rawBody = Buffer.concat(chunks).toString("utf8");
+            this.requests.push({
+                method: request.method,
+                path: url.pathname,
+                query: Object.fromEntries(url.searchParams),
+                body: rawBody ? safeParse(rawBody) : null,
+                authorization: request.headers.authorization || null
+            });
+
+            // Extension fetches are same-origin from the worker, but a preflight
+            // can still appear; answer it permissively.
+            if (request.method === "OPTIONS") {
+                return this.send(response, 200, "", {
+                    "Access-Control-Allow-Origin": "*",
+                    "Access-Control-Allow-Headers": "*",
+                    "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS"
+                });
+            }
+
+            for (const [fragment, status] of this.failures) {
+                if (url.pathname.includes(fragment)) {
+                    this.failures.delete(fragment);
+                    return this.send(response, status, { errorMessage: "forced failure" });
+                }
+            }
+
+            this.route(url, request, response);
+        });
+    }
+
+    route(url, request, response) {
+        const path = url.pathname.replace(/^\/v3\//, "");
+
+        // Both the initial code exchange and the refresh grant land here.
+        if (path === "auth/token") {
+            this.accessToken = "e2e-refreshed-token";
+            return this.send(response, 200, {
+                access_token: this.accessToken,
+                refresh_token: "e2e-refresh-token",
+                id: this.userId,
+                expires_in: 3600
+            });
+        }
+
+        if (path === "profile") {
+            return this.send(response, 200, this.profile);
+        }
+
+        if (path === "subscriptions") {
+            return this.send(response, 200, this.subscriptions);
+        }
+
+        if (path === "categories") {
+            return this.send(response, 200, this.categories);
+        }
+
+        if (path === "markers/counts") {
+            return this.send(response, 200, { unreadcounts: this.unreadCounts });
+        }
+
+        // Marking as read, and saving or unsaving an entry.
+        if (path === "markers" || path.startsWith("tags/")) {
+            return this.send(response, 200, {});
+        }
+
+        const streamMatch = /^streams\/(.+)\/contents$/.exec(path);
+        if (streamMatch) {
+            const streamId = decodeURIComponent(streamMatch[1]);
+            return this.send(response, 200, { id: streamId, items: this.streams.get(streamId) || [] });
+        }
+
+        this.send(response, 404, { errorMessage: `Unmocked path: ${path}` });
+    }
+
+    send(response, status, body, headers = {}) {
+        const payload = typeof body === "string" ? body : JSON.stringify(body);
+        response.writeHead(status, {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            ...headers
+        });
+        response.end(payload);
+    }
+}
+
+function safeParse(text) {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+module.exports = { FeedlyMockServer };

--- a/e2e/options-persistence.spec.js
+++ b/e2e/options-persistence.spec.js
@@ -64,7 +64,9 @@ test.describe("options page", () => {
 
         await page.locator("#save").click();
 
-        await expect.poll(() => dialogs.length).toBe(1);
+        await expect(async () => {
+            expect(dialogs).toHaveLength(1);
+        }).toPass();
     });
 
     test("applies the new update interval to the background alarms", async ({ signIn, optionsPage, serviceWorker }) => {
@@ -74,12 +76,13 @@ test.describe("options page", () => {
         await page.locator("#updateInterval").fill("60");
         await page.locator("#save").click();
 
-        await expect.poll(
-            () => serviceWorker.evaluate(async () => {
+        await expect(async () => {
+            const period = await serviceWorker.evaluate(async () => {
                 const alarm = await chrome.alarms.get("updateFeeds");
                 return alarm ? alarm.periodInMinutes : null;
-            })
-        ).toBe(60);
+            });
+            expect(period).toBe(60);
+        }).toPass();
     });
 
     test("clamps an update interval below the minimum", async ({ signIn, optionsPage, serviceWorker }) => {
@@ -91,9 +94,10 @@ test.describe("options page", () => {
         await page.locator("#updateInterval").fill("2");
         await page.locator("#save").click();
 
-        await expect
-            .poll(() => serviceWorker.evaluate(() => globalThis.appGlobal.options.updateInterval))
-            .toBe(10);
+        await expect(async () => {
+            const interval = await serviceWorker.evaluate(() => globalThis.appGlobal.options.updateInterval);
+            expect(interval).toBe(10);
+        }).toPass();
     });
 
     test("lists the user's categories as filter options", async ({ signIn, optionsPage }) => {
@@ -113,9 +117,12 @@ test.describe("options page", () => {
         await page.locator("#maxNumberOfFeeds").fill("33");
         await page.locator("#save").click();
 
-        await expect
-            .poll(() => serviceWorker.evaluate(async () => (await chrome.storage.local.get("maxNumberOfFeeds")).maxNumberOfFeeds))
-            .toBe(33);
+        await expect(async () => {
+            const stored = await serviceWorker.evaluate(
+                async () => (await chrome.storage.local.get("maxNumberOfFeeds")).maxNumberOfFeeds
+            );
+            expect(stored).toBe(33);
+        }).toPass();
     });
 
     test("signs the user out", async ({ signIn, optionsPage, serviceWorker }) => {

--- a/e2e/options-persistence.spec.js
+++ b/e2e/options-persistence.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require("./fixtures/extension");
+const { test, expect, RETRY } = require("./fixtures/extension");
 const { SUBSCRIPTIONS, GLOBAL_ALL, USER_ID } = require("./fixtures/feed-items");
 
 test.describe("options page", () => {
@@ -66,7 +66,7 @@ test.describe("options page", () => {
 
         await expect(async () => {
             expect(dialogs).toHaveLength(1);
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("applies the new update interval to the background alarms", async ({ signIn, optionsPage, serviceWorker }) => {
@@ -82,7 +82,7 @@ test.describe("options page", () => {
                 return alarm ? alarm.periodInMinutes : null;
             });
             expect(period).toBe(60);
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("clamps an update interval below the minimum", async ({ signIn, optionsPage, serviceWorker }) => {
@@ -97,7 +97,7 @@ test.describe("options page", () => {
         await expect(async () => {
             const interval = await serviceWorker.evaluate(() => globalThis.appGlobal.options.updateInterval);
             expect(interval).toBe(10);
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("lists the user's categories as filter options", async ({ signIn, optionsPage }) => {
@@ -122,7 +122,7 @@ test.describe("options page", () => {
                 async () => (await chrome.storage.local.get("maxNumberOfFeeds")).maxNumberOfFeeds
             );
             expect(stored).toBe(33);
-        }).toPass();
+        }).toPass(RETRY);
     });
 
     test("signs the user out", async ({ signIn, optionsPage, serviceWorker }) => {

--- a/e2e/options-persistence.spec.js
+++ b/e2e/options-persistence.spec.js
@@ -94,9 +94,18 @@ test.describe("options page", () => {
         await page.locator("#updateInterval").fill("2");
         await page.locator("#save").click();
 
+        /*
+         * Assert the raw field as well as the getter. The default is already 10
+         * and the getter floors at 10, so checking only `updateInterval` would
+         * pass even if the value never reached the background at all.
+         */
         await expect(async () => {
-            const interval = await serviceWorker.evaluate(() => globalThis.appGlobal.options.updateInterval);
-            expect(interval).toBe(10);
+            const stored = await serviceWorker.evaluate(() => ({
+                raw: globalThis.appGlobal.options._updateInterval,
+                clamped: globalThis.appGlobal.options.updateInterval
+            }));
+            expect(stored.raw).toBe(2);
+            expect(stored.clamped).toBe(10);
         }).toPass(RETRY);
     });
 

--- a/e2e/options-persistence.spec.js
+++ b/e2e/options-persistence.spec.js
@@ -1,0 +1,133 @@
+const { test, expect } = require("./fixtures/extension");
+const { SUBSCRIPTIONS, GLOBAL_ALL, USER_ID } = require("./fixtures/feed-items");
+
+test.describe("options page", () => {
+    test.beforeEach(async ({ mockApi }) => {
+        mockApi.subscriptions = SUBSCRIPTIONS;
+        mockApi.setStream(GLOBAL_ALL, []);
+        mockApi.categories = [
+            { id: `user/${USER_ID}/category/Tech`, label: "Tech" },
+            { id: `user/${USER_ID}/category/News`, label: "News" }
+        ];
+    });
+
+    test("shows the signed-in profile", async ({ signIn, optionsPage }) => {
+        await signIn();
+
+        const page = await optionsPage();
+
+        await expect(page.locator("#userInfo")).toBeVisible();
+        await expect(page.locator("#userInfo span[data-value-name='email']"))
+            .toHaveText("e2e@example.com");
+    });
+
+    test("hides the profile when signed out", async ({ optionsPage }) => {
+        const page = await optionsPage();
+
+        await expect(page.locator("#userInfo")).toBeHidden();
+    });
+
+    test("round-trips changed settings through storage", async ({ signIn, optionsPage, serviceWorker }) => {
+        await signIn();
+        const page = await optionsPage();
+
+        await page.locator("#updateInterval").fill("45");
+        await page.locator("#maxNumberOfFeeds").fill("75");
+        await page.locator("#sortBy").selectOption("oldest");
+        await page.locator("#theme").selectOption("dark");
+        await page.locator("#markReadOnClick").uncheck();
+        await page.locator("#save").click();
+
+        // The values must survive a full reload of the page.
+        await page.reload();
+        await expect(page.locator("#updateInterval")).toHaveValue("45");
+        await expect(page.locator("#maxNumberOfFeeds")).toHaveValue("75");
+        await expect(page.locator("#sortBy")).toHaveValue("oldest");
+        await expect(page.locator("#theme")).toHaveValue("dark");
+        await expect(page.locator("#markReadOnClick")).not.toBeChecked();
+
+        // And the background must have picked them up as well.
+        await expect
+            .poll(() => serviceWorker.evaluate(() => globalThis.appGlobal.options.maxNumberOfFeeds))
+            .toBe(75);
+    });
+
+    test("confirms the save with an alert", async ({ signIn, context, extensionId }) => {
+        await signIn();
+        const page = await context.newPage();
+        const dialogs = [];
+        page.on("dialog", dialog => {
+            dialogs.push(dialog.message());
+            dialog.accept();
+        });
+        await page.goto(`chrome-extension://${extensionId}/options.html`);
+
+        await page.locator("#save").click();
+
+        await expect.poll(() => dialogs.length).toBe(1);
+    });
+
+    test("applies the new update interval to the background alarms", async ({ signIn, optionsPage, serviceWorker }) => {
+        await signIn();
+        const page = await optionsPage();
+
+        await page.locator("#updateInterval").fill("60");
+        await page.locator("#save").click();
+
+        await expect.poll(
+            () => serviceWorker.evaluate(async () => {
+                const alarm = await chrome.alarms.get("updateFeeds");
+                return alarm ? alarm.periodInMinutes : null;
+            })
+        ).toBe(60);
+    });
+
+    test("clamps an update interval below the minimum", async ({ signIn, optionsPage, serviceWorker }) => {
+        await signIn();
+        const page = await optionsPage();
+
+        // The control has min=10, so bypass it the way stale storage would.
+        await page.locator("#updateInterval").evaluate(input => input.removeAttribute("min"));
+        await page.locator("#updateInterval").fill("2");
+        await page.locator("#save").click();
+
+        await expect
+            .poll(() => serviceWorker.evaluate(() => globalThis.appGlobal.options.updateInterval))
+            .toBe(10);
+    });
+
+    test("lists the user's categories as filter options", async ({ signIn, optionsPage }) => {
+        await signIn();
+
+        const page = await optionsPage();
+
+        const labels = page.locator("#categories label");
+        await expect(labels).toContainText(["Tech", "News", "Global Favorites", "Global Uncategorized"]);
+    });
+
+    test("moves settings to local storage when syncing is disabled", async ({ signIn, optionsPage, serviceWorker }) => {
+        await signIn();
+        const page = await optionsPage();
+
+        await page.locator("#disableOptionsSync").check();
+        await page.locator("#maxNumberOfFeeds").fill("33");
+        await page.locator("#save").click();
+
+        await expect
+            .poll(() => serviceWorker.evaluate(async () => (await chrome.storage.local.get("maxNumberOfFeeds")).maxNumberOfFeeds))
+            .toBe(33);
+    });
+
+    test("signs the user out", async ({ signIn, optionsPage, serviceWorker }) => {
+        await signIn();
+        const page = await optionsPage();
+        await expect(page.locator("#userInfo")).toBeVisible();
+
+        await page.locator("#logout").click();
+
+        await expect
+            .poll(() => serviceWorker.evaluate(() => globalThis.appGlobal.options.accessToken))
+            .toBe("");
+        await expect(page.locator("#userInfo")).toBeHidden();
+    });
+});

--- a/e2e/popup-actions.spec.js
+++ b/e2e/popup-actions.spec.js
@@ -1,0 +1,144 @@
+const { test, expect } = require("./fixtures/extension");
+const { item, savedItem, SUBSCRIPTIONS, GLOBAL_ALL, GLOBAL_SAVED } = require("./fixtures/feed-items");
+
+test.describe("popup actions", () => {
+    test.beforeEach(async ({ mockApi }) => {
+        mockApi.subscriptions = SUBSCRIPTIONS;
+    });
+
+    test("marks a single article as read and drops it from the list", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a"), item("b")]);
+        await signIn();
+
+        const page = await popupPage();
+        await expect(page.locator("#feed .item")).toHaveCount(2);
+
+        await page.locator("#feed .item").first().locator(".mark-read").click();
+
+        await expect(page.locator("#feed .item")).toHaveCount(1);
+        const marked = mockApi.requestsTo("/v3/markers", "POST");
+        expect(marked).toHaveLength(1);
+        expect(marked[0].body).toMatchObject({
+            action: "markAsRead",
+            type: "entries",
+            entryIds: ["a"]
+        });
+    });
+
+    test("marks everything as read", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a"), item("b"), item("c")]);
+        await signIn();
+
+        const page = await popupPage();
+        await page.locator("#mark-all-read").click();
+
+        await expect.poll(() => mockApi.requestsTo("/v3/markers", "POST").length).toBeGreaterThan(0);
+        expect(mockApi.requestsTo("/v3/markers", "POST")[0].body.entryIds).toEqual(["a", "b", "c"]);
+    });
+
+    test("sends the access token with every api call", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a")]);
+        await signIn();
+
+        await popupPage();
+
+        await expect.poll(() => mockApi.requestsFor("/contents").length).toBeGreaterThan(0);
+        expect(mockApi.requestsFor("/contents")[0].authorization).toBe("OAuth e2e-access-token");
+    });
+
+    test("refetches the stream when the refresh button is clicked", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a")]);
+        await signIn();
+
+        const page = await popupPage();
+        await expect(page.locator("#feed .item")).toHaveCount(1);
+
+        // The feed changes behind the popup's back, as it would in real use.
+        mockApi.setStream(GLOBAL_ALL, [item("x"), item("y")]);
+        await page.locator("#update-feeds").click();
+
+        await expect(page.locator("#feed .item")).toHaveCount(2);
+        await expect(page.locator("#feed .item .title").first()).toHaveText("Article x");
+    });
+
+    test("opens every article in a background tab", async ({ context, mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a"), item("b")]);
+        await signIn({ markReadOnClick: false });
+
+        const page = await popupPage();
+        await expect(page.locator("#feed .item")).toHaveCount(2);
+
+        // The article hosts do not resolve under the hermetic resolver rules,
+        // so assert on the tabs that were opened rather than on what loaded.
+        const opened = [];
+        context.on("page", newPage => opened.push(newPage.url()));
+
+        await page.locator("#open-all-news").click();
+
+        await expect.poll(() => opened.length).toBe(2);
+        expect(opened.sort()).toEqual([
+            "http://example-blog.com/posts/a",
+            "http://example-blog.com/posts/b"
+        ]);
+    });
+
+    test.describe("saved feeds", () => {
+        test("switches to the saved tab and renders saved articles", async ({ mockApi, signIn, popupPage }) => {
+            mockApi.setStream(GLOBAL_ALL, [item("unread")]);
+            mockApi.setStream(GLOBAL_SAVED, [savedItem("kept")]);
+            await signIn({ abilitySaveFeeds: true });
+
+            const page = await popupPage();
+            await expect(page.locator("#feed .item")).toHaveCount(1);
+
+            await page.locator("#tabs-checkbox").check({ force: true });
+
+            await expect(page.locator("#feed-saved")).toBeVisible();
+            await expect(page.locator("#feed-saved .item")).toHaveCount(1);
+            await expect(page.locator("#feed-saved .item .title")).toHaveText("Article kept");
+        });
+
+        test("saves an article from the unread list", async ({ mockApi, signIn, popupPage }) => {
+            mockApi.setStream(GLOBAL_ALL, [item("a")]);
+            await signIn({ abilitySaveFeeds: true });
+
+            const page = await popupPage();
+            await page.locator("#feed .item .save-feed").first().click();
+
+            await expect.poll(() => mockApi.requestsFor("/v3/tags").length).toBeGreaterThan(0);
+            const tagged = mockApi.requestsFor("/v3/tags")[0];
+            expect(tagged.method).toBe("PUT");
+            expect(tagged.body).toMatchObject({ entryIds: ["a"] });
+        });
+    });
+
+    test.describe("themes", () => {
+        test("applies the dark theme", async ({ mockApi, signIn, popupPage }) => {
+            mockApi.setStream(GLOBAL_ALL, [item("a")]);
+            await signIn({ theme: "dark" });
+
+            const page = await popupPage();
+
+            await expect(page.locator("body")).toHaveAttribute("data-theme", "dark");
+        });
+
+        test("applies the nord theme", async ({ mockApi, signIn, popupPage }) => {
+            mockApi.setStream(GLOBAL_ALL, [item("a")]);
+            await signIn({ theme: "nord" });
+
+            const page = await popupPage();
+
+            await expect(page.locator("body")).toHaveAttribute("data-theme", "nord");
+        });
+
+        test("leaves the body unmarked for the light theme", async ({ mockApi, signIn, popupPage }) => {
+            mockApi.setStream(GLOBAL_ALL, [item("a")]);
+            await signIn({ theme: "light" });
+
+            const page = await popupPage();
+            await expect(page.locator("#feed .item")).toHaveCount(1);
+
+            expect(await page.locator("body").getAttribute("data-theme")).toBeNull();
+        });
+    });
+});

--- a/e2e/popup-actions.spec.js
+++ b/e2e/popup-actions.spec.js
@@ -91,7 +91,7 @@ test.describe("popup actions", () => {
             const page = await popupPage();
             await expect(page.locator("#feed .item")).toHaveCount(1);
 
-            await page.locator("#tabs-checkbox").check({ force: true });
+            await page.locator("#tabs-checkbox").check();
 
             await expect(page.locator("#feed-saved")).toBeVisible();
             await expect(page.locator("#feed-saved .item")).toHaveCount(1);

--- a/e2e/popup-render-feeds.spec.js
+++ b/e2e/popup-render-feeds.spec.js
@@ -1,0 +1,105 @@
+const { test, expect } = require("./fixtures/extension");
+const { item, SUBSCRIPTIONS, GLOBAL_ALL } = require("./fixtures/feed-items");
+
+test.describe("popup feed rendering", () => {
+    test.beforeEach(async ({ mockApi }) => {
+        mockApi.subscriptions = SUBSCRIPTIONS;
+    });
+
+    test("shows the login prompt when signed out", async ({ popupPage }) => {
+        const page = await popupPage();
+
+        await expect(page.locator("#login")).toBeVisible();
+        await expect(page.locator("#login-btn")).toHaveText("Login");
+        await expect(page.locator("#feed")).toBeHidden();
+    });
+
+    test("renders one row per unread article", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a"), item("b"), item("c")]);
+        await signIn();
+
+        const page = await popupPage();
+
+        await expect(page.locator("#feed .item")).toHaveCount(3);
+        await expect(page.locator("#login")).toBeHidden();
+    });
+
+    test("shows the article title, blog name and link", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a", { title: "A Very Specific Headline" })]);
+        await signIn();
+
+        const page = await popupPage();
+        const article = page.locator("#feed .item").first();
+
+        await expect(article.locator(".title")).toHaveText("A Very Specific Headline");
+        await expect(article.locator(".blog-title a")).toHaveText("Example Blog,");
+        await expect(article.locator(".title"))
+            .toHaveAttribute("data-link", "http://example-blog.com/posts/a");
+    });
+
+    test("prefers the user's own subscription title", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.subscriptions = [{
+            id: "feed/http://example-blog.com/rss",
+            title: "My Renamed Feed",
+            categories: []
+        }];
+        mockApi.setStream(GLOBAL_ALL, [item("a")]);
+        await signIn();
+
+        const page = await popupPage();
+
+        await expect(page.locator("#feed .item .blog-title a")).toHaveText("My Renamed Feed,");
+    });
+
+    test("shows the empty state when there is nothing unread", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, []);
+        await signIn();
+
+        const page = await popupPage();
+
+        await expect(page.locator("#feed-empty")).toBeVisible();
+        await expect(page.locator("#feed .item")).toHaveCount(0);
+    });
+
+    test("renders the engagement badge for popular articles", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [
+            item("hot", { engagement: 7500 }),
+            item("quiet", { engagement: 0 })
+        ]);
+        await signIn();
+
+        const page = await popupPage();
+
+        const hot = page.locator("#feed .item").filter({ hasText: "Article hot" });
+        await expect(hot.locator(".engagement")).toHaveText("7K");
+        await expect(hot.locator(".engagement")).toHaveClass(/hot/);
+        await expect(page.locator("#feed .item").filter({ hasText: "Article quiet" }).locator(".engagement"))
+            .toHaveCount(0);
+    });
+
+    test("expands an article body on demand", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [
+            item("a", { summary: { content: "<p>The full body text</p>", direction: "ltr" } })
+        ]);
+        await signIn();
+
+        const page = await popupPage();
+        const article = page.locator("#feed .item").first();
+        await expect(article.locator(".content")).toBeHidden();
+
+        await article.locator(".show-content").click();
+
+        await expect(article.locator(".content")).toBeVisible();
+        await expect(article.locator(".content")).toContainText("The full body text");
+    });
+
+    test("renders category chips when the option is on", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a")]);
+        await signIn({ showCategories: true });
+
+        const page = await popupPage();
+
+        await expect(page.locator("#feed .categories")).toBeVisible();
+        await expect(page.locator("#feed .categories span")).toContainText(["All", "Tech"]);
+    });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,8 @@ module.exports = [
             "node_modules/**",
             "build/**",
             "test-results/**",
+            "playwright-report/**",
+            "coverage/**",
             "logos/**",
             "translations/**",
             "src/styles/**",
@@ -90,6 +92,30 @@ module.exports = [
         languageOptions: {
             globals: {
                 FeedlyApiClient: "readonly"
+            }
+        }
+    },
+
+    // Unit tests run under Vitest as ES modules on Node
+    {
+        files: ["test/**/*.js", "vitest.config.mjs"],
+        languageOptions: {
+            ecmaVersion: 2023,
+            sourceType: "module",
+            globals: {
+                ...globals.node
+            }
+        }
+    },
+
+    // End-to-end tests run under Playwright as CommonJS on Node
+    {
+        files: ["e2e/**/*.js", "playwright.config.js"],
+        languageOptions: {
+            ecmaVersion: 2023,
+            sourceType: "commonjs",
+            globals: {
+                ...globals.node
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       "devDependencies": {
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.63.0",
+        "@vitest/coverage-v8": "^5.0.0",
         "eslint": "^10.9.1",
         "eslint-plugin-jquery": "^1.5.1",
         "globals": "^17.11.0",
@@ -23,7 +25,256 @@
         "grunt-contrib-copy": "^1.0.0",
         "grunt-preprocess": "^5.1.0",
         "grunt-string-replace": "^1.3.3",
-        "grunt-zip": "^1.0.0"
+        "grunt-zip": "^1.0.0",
+        "jsdom": "^30.0.1",
+        "preprocess": "^3.2.0",
+        "vitest": "^5.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -201,6 +452,24 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -267,10 +536,379 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -301,6 +939,96 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-5.0.0.tgz",
+      "integrity": "sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/istanbul-lib-coverage": "^1.0.0",
+        "@vitest/istanbul-lib-report": "^1.0.0",
+        "ast-v8-to-istanbul": "^1.0.5",
+        "magicast": "^0.5.4",
+        "obug": "^2.1.4",
+        "std-env": "^4.2.0",
+        "tinyrainbow": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "5.0.0",
+        "vitest": "5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz",
+      "integrity": "sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-report": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-report/-/istanbul-lib-report-1.0.1.tgz",
+      "integrity": "sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/istanbul-lib-coverage": "1.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -412,6 +1140,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
@@ -425,6 +1175,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -448,6 +1208,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -526,6 +1296,49 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -554,6 +1367,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -571,6 +1391,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
@@ -579,6 +1410,26 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -836,6 +1687,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -883,6 +1744,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -1055,6 +1926,22 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -1465,6 +2352,19 @@
         "node": "*"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -1610,6 +2510,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-relative": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -1676,6 +2583,13 @@
       "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.15.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
@@ -1688,6 +2602,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -1804,6 +2759,291 @@
         "node": ">= 8"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1827,6 +3067,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "node_modules/make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -1849,6 +3121,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -1891,6 +3170,26 @@
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -1957,6 +3256,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/once": {
@@ -2082,6 +3395,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2142,6 +3468,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -2155,6 +3489,65 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2166,9 +3559,9 @@
       }
     },
     "node_modules/preprocess": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/preprocess/-/preprocess-3.1.0.tgz",
-      "integrity": "sha1-pE5c3Vu7WlTwrSiaru2AmV19k4o=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/preprocess/-/preprocess-3.2.0.tgz",
+      "integrity": "sha512-cO+Rf+Ose/eD+ze8Hxd9p9nS1xT8thYqv8owG/V8+IS/Remd7Z17SvaRK/oJxp08yaM8zb+QTckDKJUul2pk7g==",
       "dev": true,
       "dependencies": {
         "xregexp": "3.1.0"
@@ -2223,6 +3616,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -2264,6 +3667,41 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -2277,6 +3715,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -2308,12 +3759,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -2350,10 +3832,115 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/timeago.js": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
       "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -2367,6 +3954,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/type-check": {
@@ -2406,6 +4019,16 @@
         "node": "*"
       }
     },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2436,11 +4059,248 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webextension-polyfill": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
       "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
       "license": "MPL-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2456,6 +4316,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -2474,6 +4351,23 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xregexp": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "devDependencies": {
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.63.0",
+    "@vitest/coverage-v8": "^5.0.0",
     "eslint": "^10.9.1",
     "eslint-plugin-jquery": "^1.5.1",
     "globals": "^17.11.0",
@@ -12,7 +14,10 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-preprocess": "^5.1.0",
     "grunt-string-replace": "^1.3.3",
-    "grunt-zip": "^1.0.0"
+    "grunt-zip": "^1.0.0",
+    "jsdom": "^30.0.1",
+    "preprocess": "^3.2.0",
+    "vitest": "^5.0.0"
   },
   "repository": {
     "type": "git",
@@ -34,6 +39,12 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "build:e2e": "grunt clean:pre-build default --browser=chrome --clientId=e2e-client-id --clientSecret=e2e-client-secret",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,41 @@
+const { defineConfig } = require("@playwright/test");
+
+/*
+ * CommonJS on purpose: the package has no `"type": "module"`, and adding one
+ * would break Gruntfile.js and eslint.config.js. The e2e specs are CommonJS for
+ * the same reason.
+ */
+module.exports = defineConfig({
+    testDir: "./e2e",
+    testMatch: "**/*.spec.js",
+
+    // Each test launches its own persistent context with the extension loaded,
+    // so they are isolated but not cheap. Serial keeps the profiles apart.
+    fullyParallel: false,
+    workers: 1,
+
+    forbidOnly: Boolean(process.env.CI),
+    retries: process.env.CI ? 1 : 0,
+    timeout: 30000,
+    expect: { timeout: 10000 },
+
+    outputDir: "test-results",
+    reporter: process.env.CI
+        ? [["github"], ["html", { open: "never" }]]
+        : [["list"]],
+
+    use: {
+        trace: "on-first-retry",
+        screenshot: "only-on-failure",
+        video: "off"
+    },
+
+    projects: [
+        {
+            name: "chromium-extension",
+            // MV3 extensions load only in Playwright's bundled Chromium;
+            // Chrome and Edge dropped the side-loading flags.
+            use: { channel: "chromium" }
+        }
+    ]
+});

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadBackground } from "./helpers/load-core.js";
+
+/**
+ * background.js is the MV3 service worker: it stitches the core scripts
+ * together and exposes them to the popup and options pages through a single
+ * runtime.onMessage router.
+ */
+describe("background message router", () => {
+    let browser;
+    let appGlobal;
+    let onMessage;
+
+    beforeEach(async () => {
+        let ready;
+        ({ browser, appGlobal, onMessage, ready } = loadBackground({
+            storage: { sync: { accessToken: "token", feedlyUserId: "u1" } }
+        }));
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method) => (method === "subscriptions" ? [] : { items: [], unreadcounts: [] })
+        };
+        // Let the eager boot settle so it cannot overwrite seeded caches.
+        await ready();
+    });
+
+    it("registers exactly one message listener", () => {
+        expect(browser._events["runtime.onMessage"]).toHaveLength(1);
+    });
+
+    it("returns the current state", async () => {
+        const state = await onMessage({ type: "getState" });
+
+        expect(state).toMatchObject({ isLoggedIn: true });
+        expect(state.options).toBeDefined();
+        expect(state.environment).toBeDefined();
+    });
+
+    it("returns the options on their own", async () => {
+        const result = await onMessage({ type: "getOptions" });
+
+        expect(result.options.maxNumberOfFeeds).toBe(20);
+    });
+
+    it("rejects an unknown message type", async () => {
+        await expect(onMessage({ type: "nonsense" })).resolves.toEqual({
+            error: "Unknown message type"
+        });
+    });
+
+    it("rejects a message with no type at all", async () => {
+        await expect(onMessage({})).resolves.toEqual({ error: "Unknown message type" });
+        await expect(onMessage(null)).resolves.toEqual({ error: "Unknown message type" });
+    });
+
+    it("serves cached feeds", async () => {
+        appGlobal.cachedFeeds = [{ id: "a" }];
+
+        const result = await onMessage({ type: "getFeeds" });
+
+        expect(result.feeds).toEqual([{ id: "a" }]);
+        expect(result.isLoggedIn).toBe(true);
+    });
+
+    it("serves cached saved feeds", async () => {
+        appGlobal.cachedSavedFeeds = [{ id: "saved" }];
+
+        const result = await onMessage({ type: "getSavedFeeds" });
+
+        expect(result.feeds).toEqual([{ id: "saved" }]);
+    });
+
+    it("maps a successful mark-as-read to an ok result", async () => {
+        appGlobal.cachedFeeds = [{ id: "a" }];
+
+        await expect(onMessage({ type: "markAsRead", feedIds: ["a"] }))
+            .resolves.toEqual({ ok: true });
+    });
+
+    it("defaults a mark-as-read with no ids to an empty list", async () => {
+        await expect(onMessage({ type: "markAsRead" })).resolves.toEqual({ ok: true });
+    });
+
+    it("reports a failed mark-as-read", async () => {
+        appGlobal.feedlyApiClient.request = async () => {
+            throw { status: 500 };
+        };
+
+        await expect(onMessage({ type: "markAsRead", feedIds: ["a"] }))
+            .resolves.toEqual({ ok: false });
+    });
+
+    it("toggles a saved feed", async () => {
+        await expect(onMessage({ type: "toggleSavedFeed", feedIds: ["a"], save: true }))
+            .resolves.toEqual({ ok: true });
+    });
+
+    it("round-trips the feed tab id", async () => {
+        await onMessage({ type: "setFeedTabId", tabId: 99 });
+
+        await expect(onMessage({ type: "getFeedTabId" })).resolves.toEqual({ feedTabId: 99 });
+        expect(appGlobal.feedTabId).toBe(99);
+    });
+
+    it("reports no feed tab when none was set", async () => {
+        await expect(onMessage({ type: "getFeedTabId" })).resolves.toEqual({ feedTabId: null });
+    });
+
+    it("persists the feed tab id to session storage", async () => {
+        await onMessage({ type: "setFeedTabId", tabId: 7 });
+
+        expect(await browser.storage.session.get("_feedTabId")).toEqual({ _feedTabId: 7 });
+    });
+
+    it("opens the feedly tab", async () => {
+        await expect(onMessage({ type: "openFeedlyTab" })).resolves.toEqual({ ok: true });
+
+        expect(browser._calls.tabsCreated).toHaveLength(1);
+    });
+
+    it("resets the counter", async () => {
+        await expect(onMessage({ type: "resetCounter" })).resolves.toEqual({ ok: true });
+    });
+
+    it("turns an unexpected failure into a generic error", async () => {
+        // getFeeds with a broken cache throws inside the router.
+        appGlobal.cachedFeeds = null;
+
+        await expect(onMessage({ type: "getFeeds" })).resolves.toEqual({ error: "Internal error" });
+    });
+});
+
+describe("service worker startup", () => {
+    it("restores the feed tab id from session storage after a restart", async () => {
+        const { appGlobal, ready } = loadBackground({
+            storage: { session: { _feedTabId: 42 } }
+        });
+
+        await ready();
+
+        expect(appGlobal.feedTabId).toBe(42);
+    });
+
+    it("initialises only once no matter how many messages arrive", async () => {
+        let platformInfoCalls = 0;
+        const { browser, onMessage, ready } = loadBackground({
+            storage: { sync: { accessToken: "token" } }
+        });
+        browser.runtime.getPlatformInfo = async () => {
+            platformInfoCalls++;
+            return { os: "win" };
+        };
+        await ready();
+        const afterBoot = platformInfoCalls;
+
+        await Promise.all([
+            onMessage({ type: "getOptions" }),
+            onMessage({ type: "getOptions" }),
+            onMessage({ type: "getOptions" })
+        ]);
+
+        // ensureInitialized memoises, so no message re-runs initialisation.
+        expect(platformInfoCalls).toBe(afterBoot);
+    });
+
+    it("sets the popup page during initialisation", async () => {
+        const { browser, ready } = loadBackground();
+
+        await ready();
+
+        expect(browser._calls.setPopup).toContain("popup.html");
+    });
+
+    it("clears the popup when opening the site on click", async () => {
+        const { browser, ready } = loadBackground({
+            storage: { sync: { openSiteOnIconClick: true } }
+        });
+
+        await ready();
+
+        expect(browser._calls.setPopup).toContain("");
+    });
+});

--- a/test/core.api-wrapper.test.js
+++ b/test/core.api-wrapper.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+
+/**
+ * Builds an API client stub driven by a queue of scripted outcomes.
+ * Each outcome is either `{ resolve }` or `{ reject }`.
+ */
+function scriptedClient(outcomes) {
+    const calls = [];
+    return {
+        calls,
+        accessToken: "token",
+        request: async (method, settings) => {
+            calls.push({ method, settings });
+            const outcome = outcomes.shift();
+            if (!outcome) {
+                throw new Error(`Unexpected extra request: ${method}`);
+            }
+            if (outcome.reject) {
+                throw outcome.reject;
+            }
+            return outcome.resolve;
+        }
+    };
+}
+
+describe("apiRequestWrapper", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.feedlyUserId = "u1";
+    });
+
+    it("rejects and goes inactive when there is no access token", async () => {
+        await expect(ctx.apiRequestWrapper("profile")).rejects.toMatchObject({
+            message: "No access token available"
+        });
+
+        expect(appGlobal.isLoggedIn).toBe(false);
+        expect(browser._calls.setBadgeText).toEqual([""]);
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.inactive]);
+        expect(browser._calls.alarmsCleared).toEqual(["updateCounter", "updateFeeds"]);
+    });
+
+    it("marks the session active on a successful request", async () => {
+        appGlobal.options.accessToken = "token";
+        appGlobal.feedlyApiClient = scriptedClient([{ resolve: { id: "user-1" } }]);
+
+        await expect(ctx.apiRequestWrapper("profile")).resolves.toEqual({ id: "user-1" });
+
+        expect(appGlobal.isLoggedIn).toBe(true);
+        expect(browser._calls.setBadgeBackgroundColor).toEqual(["#CF0016"]);
+    });
+
+    it("refreshes the token and retries once after a 401", async () => {
+        appGlobal.options.accessToken = "stale";
+        appGlobal.options.refreshToken = "refresh";
+        const client = scriptedClient([
+            { reject: { status: 401 } },
+            { resolve: { access_token: "fresh", id: "user-1" } },
+            { resolve: { unreadcounts: [] } }
+        ]);
+        appGlobal.feedlyApiClient = client;
+
+        await expect(ctx.apiRequestWrapper("markers/counts")).resolves.toEqual({ unreadcounts: [] });
+
+        expect(client.calls.map(call => call.method))
+            .toEqual(["markers/counts", "auth/token", "markers/counts"]);
+        expect(appGlobal.options.accessToken).toBe("fresh");
+        expect(client.accessToken).toBe("fresh");
+    });
+
+    it("persists the refreshed token", async () => {
+        appGlobal.options.accessToken = "stale";
+        appGlobal.options.refreshToken = "refresh";
+        appGlobal.feedlyApiClient = scriptedClient([
+            { reject: { status: 401 } },
+            { resolve: { access_token: "fresh", id: "user-9" } },
+            { resolve: {} }
+        ]);
+
+        await ctx.apiRequestWrapper("markers/counts");
+
+        const stored = await browser.storage.sync.get(null);
+        expect(stored.accessToken).toBe("fresh");
+        expect(stored.feedlyUserId).toBe("user-9");
+    });
+
+    // The retry deliberately bypasses the wrapper, so it cannot loop.
+    it("does not refresh twice when the retry also fails", async () => {
+        appGlobal.options.accessToken = "stale";
+        appGlobal.options.refreshToken = "refresh";
+        const client = scriptedClient([
+            { reject: { status: 401 } },
+            { resolve: { access_token: "fresh", id: "user-1" } },
+            { reject: { status: 401 } }
+        ]);
+        appGlobal.feedlyApiClient = client;
+
+        await expect(ctx.apiRequestWrapper("markers/counts")).rejects.toHaveProperty("status", 401);
+
+        expect(client.calls.filter(call => call.method === "auth/token")).toHaveLength(1);
+    });
+
+    it("propagates non-401 failures without refreshing", async () => {
+        appGlobal.options.accessToken = "token";
+        appGlobal.options.refreshToken = "refresh";
+        const client = scriptedClient([{ reject: { status: 500 } }]);
+        appGlobal.feedlyApiClient = client;
+
+        await expect(ctx.apiRequestWrapper("profile")).rejects.toHaveProperty("status", 500);
+
+        expect(client.calls).toHaveLength(1);
+    });
+});
+
+describe("refreshAccessToken", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore());
+    });
+
+    it("goes inactive and throws when there is no refresh token", async () => {
+        await expect(ctx.refreshAccessToken()).rejects.toMatchObject({
+            message: "No refresh token available"
+        });
+
+        expect(appGlobal.isLoggedIn).toBe(false);
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.inactive]);
+    });
+
+    it("goes inactive when the refresh token is rejected", async () => {
+        appGlobal.options.refreshToken = "revoked";
+        appGlobal.feedlyApiClient = scriptedClient([{ reject: { status: 403 } }]);
+
+        await expect(ctx.refreshAccessToken()).rejects.toHaveProperty("status", 403);
+
+        expect(appGlobal.isLoggedIn).toBe(false);
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.inactive]);
+    });
+
+    it("keeps the session alive on other failures", async () => {
+        appGlobal.options.refreshToken = "refresh";
+        appGlobal.feedlyApiClient = scriptedClient([{ reject: { status: 500 } }]);
+
+        await expect(ctx.refreshAccessToken()).rejects.toHaveProperty("status", 500);
+
+        expect(browser._calls.setIcon).toEqual([]);
+    });
+
+    it("sends the refresh grant without the stale authorization header", async () => {
+        appGlobal.options.refreshToken = "refresh";
+        const client = scriptedClient([{ resolve: { access_token: "fresh", id: "u1" } }]);
+        appGlobal.feedlyApiClient = client;
+
+        await ctx.refreshAccessToken();
+
+        expect(client.calls[0].settings).toMatchObject({
+            method: "POST",
+            skipAuthentication: true
+        });
+        expect(client.calls[0].settings.parameters).toMatchObject({
+            refresh_token: "refresh",
+            grant_type: "refresh_token"
+        });
+    });
+});

--- a/test/core.counter.test.js
+++ b/test/core.counter.test.js
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+
+describe("setBadgeCounter", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore());
+    });
+
+    it.each([
+        [0, ""],
+        [1, "1"],
+        [42, "42"],
+        [999, "999"],
+        [1000, "1k+"],
+        [1999, "1k+"],
+        [12345, "12k+"],
+        [999999, "999k+"]
+    ])("renders an unread count of %i as %j", (count, expected) => {
+        ctx.setBadgeCounter(count);
+
+        expect(browser._calls.setBadgeText).toEqual([expected]);
+    });
+
+    it("clears the badge entirely when the counter is switched off", () => {
+        appGlobal.options.showCounter = false;
+
+        ctx.setBadgeCounter(1234);
+
+        expect(browser._calls.setBadgeText).toEqual([""]);
+    });
+
+    it("greys the icon when there is nothing unread and the option is on", () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+
+        ctx.setBadgeCounter(0);
+
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.inactive]);
+    });
+
+    it("keeps the default icon when there is something unread", () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+
+        ctx.setBadgeCounter(3);
+
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.default]);
+    });
+
+    it("keeps the default icon at zero when greying is off", () => {
+        ctx.setBadgeCounter(0);
+
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.default]);
+    });
+});
+
+describe("makeMarkersRequest", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    /** Stubs the API client with canned marker counts and subscriptions. */
+    function stubApi({ unreadcounts = [], subscriptions = [] }) {
+        appGlobal.options.accessToken = "token";
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method) => {
+                if (method === "subscriptions") {
+                    return subscriptions;
+                }
+                return { unreadcounts };
+            }
+        };
+    }
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.feedlyUserId = "u1";
+    });
+
+    it("uses the global count when no filters are enabled", async () => {
+        stubApi({
+            unreadcounts: [
+                { id: "user/u1/category/global.all", count: 17 },
+                { id: "feed/other", count: 99 }
+            ]
+        });
+
+        await ctx.makeMarkersRequest();
+
+        expect(browser._calls.setBadgeText).toEqual(["17"]);
+    });
+
+    it("shows nothing when the global count is absent", async () => {
+        stubApi({ unreadcounts: [{ id: "feed/other", count: 99 }] });
+
+        await ctx.makeMarkersRequest();
+
+        expect(browser._calls.setBadgeText).toEqual([""]);
+    });
+
+    it("sums only the selected categories when filters are enabled", async () => {
+        appGlobal.options.isFiltersEnabled = true;
+        appGlobal.options.filters = ["user/u1/category/Tech", "user/u1/category/News"];
+        stubApi({
+            unreadcounts: [
+                { id: "user/u1/category/Tech", count: 10 },
+                { id: "user/u1/category/News", count: 5 },
+                { id: "user/u1/category/Ignored", count: 100 }
+            ]
+        });
+
+        await ctx.makeMarkersRequest();
+
+        expect(browser._calls.setBadgeText).toEqual(["15"]);
+    });
+
+    /*
+     * A feed belonging to several selected categories is counted once per
+     * category, so core.js subtracts the surplus (core.js:599-614).
+     */
+    it("subtracts a feed counted twice across two selected categories", async () => {
+        appGlobal.options.isFiltersEnabled = true;
+        appGlobal.options.filters = ["user/u1/category/Tech", "user/u1/category/News"];
+        stubApi({
+            unreadcounts: [
+                { id: "user/u1/category/Tech", count: 10 },
+                { id: "user/u1/category/News", count: 5 },
+                { id: "feed/dupe", count: 3 }
+            ],
+            subscriptions: [{
+                id: "feed/dupe",
+                categories: [
+                    { id: "user/u1/category/Tech" },
+                    { id: "user/u1/category/News" }
+                ]
+            }]
+        });
+
+        await ctx.makeMarkersRequest();
+
+        // 15 raw, minus the one surplus copy of the 3 unread items.
+        expect(browser._calls.setBadgeText).toEqual(["12"]);
+    });
+
+    it("subtracts twice for a feed spanning three selected categories", async () => {
+        appGlobal.options.isFiltersEnabled = true;
+        appGlobal.options.filters = ["cat/A", "cat/B", "cat/C"];
+        stubApi({
+            unreadcounts: [
+                { id: "cat/A", count: 6 },
+                { id: "cat/B", count: 6 },
+                { id: "cat/C", count: 6 },
+                { id: "feed/dupe", count: 6 }
+            ],
+            subscriptions: [{
+                id: "feed/dupe",
+                categories: [{ id: "cat/A" }, { id: "cat/B" }, { id: "cat/C" }]
+            }]
+        });
+
+        await ctx.makeMarkersRequest();
+
+        // 18 raw, minus two surplus copies of 6.
+        expect(browser._calls.setBadgeText).toEqual(["6"]);
+    });
+
+    it("does not subtract for a feed in only one selected category", async () => {
+        appGlobal.options.isFiltersEnabled = true;
+        appGlobal.options.filters = ["cat/A"];
+        stubApi({
+            unreadcounts: [{ id: "cat/A", count: 8 }, { id: "feed/single", count: 8 }],
+            subscriptions: [{ id: "feed/single", categories: [{ id: "cat/A" }, { id: "cat/Unselected" }] }]
+        });
+
+        await ctx.makeMarkersRequest();
+
+        expect(browser._calls.setBadgeText).toEqual(["8"]);
+    });
+
+    /*
+     * KNOWN BEHAVIOUR (core.js:589-617): with filters enabled the summing loop
+     * sits inside the same try block as, and after, `await
+     * getUserSubscriptions()`. A failed subscription lookup therefore skips the
+     * sum entirely and the badge clears rather than falling back to the
+     * un-deduplicated total.
+     */
+    it("clears the badge when the subscription lookup fails", async () => {
+        appGlobal.options.isFiltersEnabled = true;
+        appGlobal.options.filters = ["cat/A"];
+        appGlobal.options.accessToken = "token";
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method) => {
+                if (method === "subscriptions") {
+                    throw new Error("network down");
+                }
+                return { unreadcounts: [{ id: "cat/A", count: 4 }] };
+            }
+        };
+
+        await ctx.makeMarkersRequest();
+
+        expect(browser._calls.setBadgeText).toEqual([""]);
+    });
+});
+
+describe("updateCounter", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.feedlyUserId = "u1";
+        appGlobal.options.accessToken = "token";
+    });
+
+    it("requests counts newer than the last reset when that option is on", async () => {
+        const requested = [];
+        appGlobal.options.resetCounterOnClick = true;
+        await browser.storage.local.set({ lastCounterResetTime: 1700000000000 });
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method, settings) => {
+                requested.push(settings.parameters);
+                return { unreadcounts: [] };
+            }
+        };
+
+        await ctx.updateCounter();
+
+        expect(requested[0]).toEqual({ newerThan: 1700000000000 });
+    });
+
+    it("resets the stored reset time when the option is off", async () => {
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => ({ unreadcounts: [] })
+        };
+
+        await ctx.updateCounter();
+
+        expect((await browser.storage.local.get("lastCounterResetTime")).lastCounterResetTime).toBe(0);
+    });
+
+    it("clears the badge when the request fails", async () => {
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => {
+                throw { status: 500 };
+            }
+        };
+
+        await ctx.updateCounter();
+
+        expect(browser._calls.setBadgeText).toContain("");
+    });
+});
+
+describe("resetCounter", () => {
+    it("blanks the badge and records the reset time", async () => {
+        const { ctx, browser } = loadCore();
+
+        await ctx.resetCounter();
+
+        expect(browser._calls.setBadgeText).toEqual([""]);
+        const stored = await browser.storage.local.get("lastCounterResetTime");
+        expect(stored.lastCounterResetTime).toBeGreaterThan(0);
+    });
+});

--- a/test/core.misc.test.js
+++ b/test/core.misc.test.js
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+
+describe("filterByNewFeeds", () => {
+    let ctx;
+    let browser;
+
+    beforeEach(() => {
+        ({ ctx, browser } = loadCore());
+    });
+
+    const feed = (id, date) => ({ id, date: new Date(date) });
+
+    it("returns everything when nothing has been seen yet", async () => {
+        const feeds = [feed("a", "2024-01-01"), feed("b", "2024-02-01")];
+
+        await expect(ctx.filterByNewFeeds(feeds)).resolves.toHaveLength(2);
+    });
+
+    it("returns only feeds newer than the last seen time", async () => {
+        await browser.storage.local.set({ lastFeedTimeTicks: new Date("2024-01-15").getTime() });
+        const feeds = [feed("old", "2024-01-01"), feed("new", "2024-02-01")];
+
+        const result = await ctx.filterByNewFeeds(feeds);
+
+        expect(result.map(item => item.id)).toEqual(["new"]);
+    });
+
+    it("treats a feed exactly at the boundary as already seen", async () => {
+        const boundary = new Date("2024-01-15").getTime();
+        await browser.storage.local.set({ lastFeedTimeTicks: boundary });
+
+        await expect(ctx.filterByNewFeeds([feed("edge", boundary)])).resolves.toEqual([]);
+    });
+
+    it("advances the stored marker to the newest feed seen", async () => {
+        const newest = new Date("2024-03-01").getTime();
+        await ctx.filterByNewFeeds([feed("a", "2024-01-01"), feed("b", newest)]);
+
+        const stored = await browser.storage.local.get("lastFeedTimeTicks");
+        expect(stored.lastFeedTimeTicks).toBe(newest);
+    });
+
+    it("leaves the marker alone when nothing is new", async () => {
+        const marker = new Date("2024-06-01").getTime();
+        await browser.storage.local.set({ lastFeedTimeTicks: marker });
+
+        await ctx.filterByNewFeeds([feed("old", "2024-01-01")]);
+
+        expect((await browser.storage.local.get("lastFeedTimeTicks")).lastFeedTimeTicks).toBe(marker);
+    });
+
+    /*
+     * KNOWN BUG: parseFeeds emits `date` as a Date, but updateFeeds writes the
+     * cache straight into storage where it is JSON-serialised to a string. After
+     * a service-worker restart the comparison at core.js:514 is string vs Date,
+     * which is always false, so notifications go silent until the next fetch.
+     */
+    it("treats feeds whose date came back from storage as a string as not new", async () => {
+        await browser.storage.local.set({ lastFeedTimeTicks: new Date("2020-01-01").getTime() });
+        const revived = [{ id: "revived", date: new Date("2024-01-01").toISOString() }];
+
+        await expect(ctx.filterByNewFeeds(revived)).resolves.toEqual([]);
+    });
+});
+
+describe("removeFeedFromCache", () => {
+    it("removes the matching feed from both caches", () => {
+        const { ctx, appGlobal } = loadCore();
+        appGlobal.cachedFeeds = [{ id: "a" }, { id: "b" }];
+
+        ctx.removeFeedFromCache("a");
+
+        expect(appGlobal.cachedFeeds.map(feed => feed.id)).toEqual(["b"]);
+    });
+
+    it("leaves the cache untouched for an unknown id", () => {
+        const { ctx, appGlobal } = loadCore();
+        appGlobal.cachedFeeds = [{ id: "a" }];
+
+        ctx.removeFeedFromCache("missing");
+
+        expect(appGlobal.cachedFeeds).toHaveLength(1);
+    });
+});
+
+describe("getUserSubscriptions", () => {
+    let ctx;
+    let appGlobal;
+
+    beforeEach(() => {
+        ({ ctx, appGlobal } = loadCore());
+        appGlobal.options.accessToken = "token";
+    });
+
+    it("requests the subscriptions only once and reuses the promise", async () => {
+        let requests = 0;
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => {
+                requests++;
+                return [{ id: "feed/a" }];
+            }
+        };
+
+        await Promise.all([ctx.getUserSubscriptions(), ctx.getUserSubscriptions()]);
+        await ctx.getUserSubscriptions();
+
+        expect(requests).toBe(1);
+    });
+
+    it("refetches when the cache is explicitly invalidated", async () => {
+        let requests = 0;
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => {
+                requests++;
+                return [];
+            }
+        };
+
+        await ctx.getUserSubscriptions();
+        await ctx.getUserSubscriptions(true);
+
+        expect(requests).toBe(2);
+    });
+
+    it("clears the memoised promise after a failure so the next call retries", async () => {
+        let requests = 0;
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => {
+                requests++;
+                if (requests === 1) {
+                    throw { status: 500 };
+                }
+                return [{ id: "feed/a" }];
+            }
+        };
+
+        await expect(ctx.getUserSubscriptions()).rejects.toHaveProperty("status", 500);
+        await expect(ctx.getUserSubscriptions()).resolves.toEqual([{ id: "feed/a" }]);
+        expect(requests).toBe(2);
+    });
+});
+
+describe("markAsRead", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.accessToken = "token";
+        appGlobal.cachedFeeds = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    });
+
+    it("posts the ids and drops them from the cache", async () => {
+        const calls = [];
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method, settings) => {
+                calls.push({ method, settings });
+                return {};
+            }
+        };
+
+        await expect(ctx.markAsRead(["a", "b"])).resolves.toBe(true);
+
+        expect(calls[0].method).toBe("markers");
+        expect(calls[0].settings.method).toBe("POST");
+        expect(calls[0].settings.body).toEqual({
+            action: "markAsRead",
+            type: "entries",
+            entryIds: ["a", "b"]
+        });
+        expect(appGlobal.cachedFeeds.map(feed => feed.id)).toEqual(["c"]);
+    });
+
+    it("decrements the badge by the number marked", async () => {
+        appGlobal.feedlyApiClient = { accessToken: "token", request: async () => ({}) };
+        ctx.setBadgeCounter(10);
+
+        await ctx.markAsRead(["a", "b"]);
+
+        expect(browser._calls.setBadgeText.at(-1)).toBe("8");
+    });
+
+    /*
+     * KNOWN BUG (core.js:940): the badge text is read back and coerced with `+`.
+     * Above 999 it reads "1k+", which coerces to NaN, so the decrement is
+     * silently skipped and the badge keeps its stale value.
+     */
+    it("fails to decrement an abbreviated badge above 999", async () => {
+        appGlobal.feedlyApiClient = { accessToken: "token", request: async () => ({}) };
+        ctx.setBadgeCounter(1500);
+
+        await ctx.markAsRead(["a"]);
+
+        expect(browser._calls.setBadgeText.at(-1)).toBe("1k+");
+    });
+
+    it("reports failure and keeps the cache when the request fails", async () => {
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => {
+                throw { status: 500 };
+            }
+        };
+
+        await expect(ctx.markAsRead(["a"])).resolves.toBe(false);
+        expect(appGlobal.cachedFeeds).toHaveLength(3);
+    });
+});
+
+describe("toggleSavedFeed", () => {
+    let ctx;
+    let appGlobal;
+    let calls;
+
+    beforeEach(() => {
+        ({ ctx, appGlobal } = loadCore());
+        appGlobal.options.accessToken = "token";
+        appGlobal.options.feedlyUserId = "u1";
+        appGlobal.cachedFeeds = [{ id: "a", isSaved: false }];
+        calls = [];
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method, settings) => {
+                calls.push({ method, settings });
+                return {};
+            }
+        };
+    });
+
+    it("puts the entry into the saved tag and flags the cache", async () => {
+        await expect(ctx.toggleSavedFeed(["a"], true)).resolves.toBe(true);
+
+        expect(calls[0].method).toBe("tags/user%2Fu1%2Ftag%2Fglobal.saved");
+        expect(calls[0].settings.method).toBe("PUT");
+        expect(appGlobal.cachedFeeds[0].isSaved).toBe(true);
+    });
+
+    it("deletes the entry from the saved tag when unsaving", async () => {
+        appGlobal.cachedFeeds = [{ id: "a", isSaved: true }];
+
+        await ctx.toggleSavedFeed(["a"], false);
+
+        expect(calls[0].method).toBe("tags/user%2Fu1%2Ftag%2Fglobal.saved/a");
+        expect(calls[0].settings.method).toBe("DELETE");
+        expect(appGlobal.cachedFeeds[0].isSaved).toBe(false);
+    });
+
+    it("reports failure and leaves the cache alone when the request fails", async () => {
+        appGlobal.feedlyApiClient.request = async () => {
+            throw { status: 500 };
+        };
+
+        await expect(ctx.toggleSavedFeed(["a"], true)).resolves.toBe(false);
+        expect(appGlobal.cachedFeeds[0].isSaved).toBe(false);
+    });
+});
+
+describe("scheduling", () => {
+    it("creates both alarms and clears them again", () => {
+        const { ctx, browser, appGlobal } = loadCore();
+
+        ctx.startSchedule(15, true);
+
+        expect(browser._calls.alarmsCreated.map(alarm => alarm.name))
+            .toEqual(["updateCounter", "updateFeeds"]);
+        expect(browser._calls.alarmsCreated[0].info).toEqual({ periodInMinutes: 15 });
+
+        ctx.stopSchedule();
+
+        expect(browser._calls.alarmsCleared.slice(-2)).toEqual(["updateCounter", "updateFeeds"]);
+        expect(appGlobal.options.showCounter).toBe(true);
+    });
+
+    it("skips the counter alarm when the badge is disabled", () => {
+        const { ctx, browser, appGlobal } = loadCore();
+        appGlobal.options.showCounter = false;
+
+        ctx.startSchedule(10, true);
+
+        expect(browser._calls.alarmsCreated.map(alarm => alarm.name)).toEqual(["updateFeeds"]);
+    });
+
+    // A worker waking for an alarm must not recreate the alarms it woke for.
+    it("leaves existing alarms alone when told not to recreate them", () => {
+        const { ctx, browser } = loadCore();
+
+        ctx.startSchedule(10, false);
+
+        expect(browser._calls.alarmsCreated).toEqual([]);
+        expect(browser._calls.alarmsCleared).toEqual([]);
+    });
+});
+
+describe("login status", () => {
+    it("clears the cache and stops the schedule when going inactive", () => {
+        const { ctx, browser, appGlobal } = loadCore();
+        appGlobal.cachedFeeds = [{ id: "a" }];
+        appGlobal.isLoggedIn = true;
+
+        ctx.setInactiveStatus();
+
+        expect(appGlobal.cachedFeeds).toEqual([]);
+        expect(appGlobal.isLoggedIn).toBe(false);
+        expect(browser._calls.setBadgeText).toEqual([""]);
+        expect(browser._calls.alarmsCleared).toEqual(["updateCounter", "updateFeeds"]);
+    });
+});

--- a/test/core.options.test.js
+++ b/test/core.options.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+
+describe("options", () => {
+    describe("clamping getters", () => {
+        let appGlobal;
+
+        beforeEach(() => {
+            ({ appGlobal } = loadCore());
+        });
+
+        it.each([
+            [1, 10],
+            [9, 10],
+            [10, 10],
+            [45, 45]
+        ])("raises an update interval of %i minutes to %i", (stored, expected) => {
+            appGlobal.options.updateInterval = stored;
+
+            expect(appGlobal.options.updateInterval).toBe(expected);
+        });
+
+        it("keeps the raw update interval in the private field", () => {
+            appGlobal.options.updateInterval = 3;
+
+            expect(appGlobal.options._updateInterval).toBe(3);
+            expect(appGlobal.options.updateInterval).toBe(10);
+        });
+
+        it.each([
+            ["popupWidth", 100, 380],
+            ["popupWidth", 380, 380],
+            ["popupWidth", 600, 600],
+            ["popupWidth", 800, 800],
+            ["popupWidth", 5000, 800],
+            ["expandedPopupWidth", 10, 380],
+            ["expandedPopupWidth", 700, 700],
+            ["expandedPopupWidth", 1200, 800]
+        ])("clamps %s of %i to %i", (option, stored, expected) => {
+            appGlobal.options[option] = stored;
+
+            expect(appGlobal.options[option]).toBe(expected);
+        });
+    });
+
+    describe("stream id getters", () => {
+        it("derive the feedly stream ids from the user id", () => {
+            const { appGlobal } = loadCore();
+            appGlobal.options.feedlyUserId = "user-42";
+
+            expect(appGlobal.savedGroup).toBe("user/user-42/tag/global.saved");
+            expect(appGlobal.globalGroup).toBe("user/user-42/category/global.all");
+            expect(appGlobal.globalUncategorized).toBe("user/user-42/category/global.uncategorized");
+            expect(appGlobal.globalFavorites).toBe("user/user-42/category/global.must");
+        });
+    });
+
+    describe("writeOptions", () => {
+        it("persists public options and skips private fields", async () => {
+            const { ctx, browser, appGlobal } = loadCore();
+            appGlobal.options.maxNumberOfFeeds = 42;
+
+            await ctx.writeOptions();
+
+            const stored = await browser.storage.sync.get(null);
+            expect(stored.maxNumberOfFeeds).toBe(42);
+            expect(stored).not.toHaveProperty("_updateInterval");
+            expect(stored).not.toHaveProperty("_popupWidth");
+            expect(stored).not.toHaveProperty("_expandedPopupWidth");
+        });
+
+        it("persists the resolved value of a clamping getter, not the raw one", async () => {
+            const { ctx, browser, appGlobal } = loadCore();
+            appGlobal.options.updateInterval = 2;
+
+            await ctx.writeOptions();
+
+            expect((await browser.storage.sync.get(null)).updateInterval).toBe(10);
+        });
+
+        it("writes to local storage when sync is disabled", async () => {
+            const { ctx, browser, appGlobal } = loadCore();
+            appGlobal.options.disableOptionsSync = true;
+
+            await ctx.writeOptions();
+
+            expect(await browser.storage.local.get("maxNumberOfFeeds")).toHaveProperty("maxNumberOfFeeds");
+            expect(await browser.storage.sync.get(null)).toEqual({});
+        });
+    });
+
+    describe("readOptions", () => {
+        it("coerces stored values to the type of the default", async () => {
+            const { ctx, appGlobal } = loadCore({
+                storage: {
+                    sync: {
+                        maxNumberOfFeeds: "35",
+                        soundVolume: "0.5",
+                        sortBy: "oldest"
+                    }
+                }
+            });
+
+            await ctx.readOptions();
+
+            expect(appGlobal.options.maxNumberOfFeeds).toBe(35);
+            expect(appGlobal.options.soundVolume).toBe(0.5);
+            expect(appGlobal.options.sortBy).toBe("oldest");
+        });
+
+        /*
+         * KNOWN BEHAVIOUR (core.js:1119): booleans go through Boolean(), so any
+         * non-empty string is true. A legacy record holding the string "false"
+         * therefore reads back as true.
+         */
+        it.each([
+            [true, true],
+            [false, false],
+            ["", false],
+            [0, false],
+            [1, true],
+            ["false", true]
+        ])("coerces a stored boolean of %j to %j", async (stored, expected) => {
+            const { ctx, appGlobal } = loadCore({ storage: { sync: { showCounter: stored } } });
+
+            await ctx.readOptions();
+
+            expect(appGlobal.options.showCounter).toBe(expected);
+        });
+
+        it("ignores private fields held in storage", async () => {
+            const { ctx, appGlobal } = loadCore({ storage: { sync: { _popupWidth: 9999 } } });
+
+            await ctx.readOptions();
+
+            expect(appGlobal.options._popupWidth).toBe(500);
+        });
+
+        it("routes reads through local storage when sync is disabled", async () => {
+            const { ctx, appGlobal } = loadCore({
+                storage: {
+                    local: { disableOptionsSync: true, maxNumberOfFeeds: 7 },
+                    sync: { maxNumberOfFeeds: 99 }
+                }
+            });
+
+            await ctx.readOptions();
+
+            expect(appGlobal.options.maxNumberOfFeeds).toBe(7);
+        });
+
+        it("treats a stored access token as being logged in", async () => {
+            const { ctx, appGlobal } = loadCore({ storage: { sync: { accessToken: "token" } } });
+
+            await ctx.readOptions();
+
+            expect(appGlobal.isLoggedIn).toBe(true);
+        });
+
+        it("is logged out when no token is stored", async () => {
+            const { ctx, appGlobal } = loadCore();
+
+            await ctx.readOptions();
+
+            expect(appGlobal.isLoggedIn).toBe(false);
+        });
+
+        it("picks up the current ui language", async () => {
+            const { ctx, appGlobal } = loadCore({ uiLanguage: "de" });
+
+            await ctx.readOptions();
+
+            expect(appGlobal.options.currentUiLanguage).toBe("de");
+        });
+
+        it("restores cached feeds from local storage", async () => {
+            const { ctx, appGlobal } = loadCore({
+                storage: { local: { cachedFeeds: [{ id: "a" }], cachedSavedFeeds: [{ id: "b" }] } }
+            });
+
+            await ctx.readOptions();
+
+            expect(appGlobal.cachedFeeds).toEqual([{ id: "a" }]);
+            expect(appGlobal.cachedSavedFeeds).toEqual([{ id: "b" }]);
+        });
+
+        it("falls back to empty caches when storage holds a non-array", async () => {
+            const { ctx, appGlobal } = loadCore({
+                storage: { local: { cachedFeeds: "corrupted", cachedSavedFeeds: null } }
+            });
+
+            await ctx.readOptions();
+
+            expect(appGlobal.cachedFeeds).toEqual([]);
+            expect(appGlobal.cachedSavedFeeds).toEqual([]);
+        });
+    });
+});

--- a/test/core.parse-feeds.test.js
+++ b/test/core.parse-feeds.test.js
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+import { SUBSCRIPTIONS, item, stream } from "./fixtures/feedly-responses.js";
+
+/**
+ * parseFeeds() turns a raw Feedly stream response into the view model the popup
+ * renders. It is the densest branch cluster in the codebase, so it gets the
+ * most coverage.
+ */
+describe("parseFeeds", () => {
+    let ctx;
+    let appGlobal;
+
+    beforeEach(() => {
+        // A fresh vm context per test is the only way to reset appGlobal and the
+        // other module-level state these scripts keep.
+        ({ ctx, appGlobal } = loadCore());
+        appGlobal.options.accessToken = "test-token";
+        appGlobal.feedlyApiClient = {
+            accessToken: "test-token",
+            request: async (method) => (method === "subscriptions" ? SUBSCRIPTIONS : {})
+        };
+    });
+
+    const parse = (items) => ctx.parseFeeds(stream(items));
+
+    it("prefers the subscription title over the origin title", async () => {
+        const [feed] = await parse([item()]);
+
+        expect(feed.blog).toBe("Blog A (renamed by user)");
+    });
+
+    it("falls back to the origin title when the stream is not subscribed", async () => {
+        const [feed] = await parse([item({
+            origin: { htmlUrl: "https://other.com", streamId: "feed/unknown", title: "Origin Title" }
+        })]);
+
+        expect(feed.blog).toBe("Origin Title");
+    });
+
+    it("reduces the blog url to its origin", async () => {
+        const [feed] = await parse([item()]);
+
+        expect(feed.blogUrl).toBe("https://blog-a.com");
+    });
+
+    it("falls back to '#' when the origin url cannot be parsed", async () => {
+        const [feed] = await parse([item({ origin: { htmlUrl: "not-a-url", streamId: "x" } })]);
+
+        expect(feed.blogUrl).toBe("#");
+    });
+
+    it("prefers the alternate link over the blog url for the item url", async () => {
+        const [feed] = await parse([item()]);
+
+        expect(feed.url).toBe("https://blog-a.com/posts/1");
+    });
+
+    it("falls back to the blog url when there is no alternate link", async () => {
+        const [feed] = await parse([item({ alternate: undefined })]);
+
+        expect(feed.url).toBe("https://blog-a.com");
+    });
+
+    describe("title handling", () => {
+        it("derives a title from the summary when the item has none", async () => {
+            const [feed] = await parse([item({
+                title: null,
+                summary: { content: "<p>Derived <b>title</b> text</p>" }
+            })]);
+
+            expect(feed.title).toBe("Derived title text");
+        });
+
+        it("truncates a derived title at 100 characters", async () => {
+            const longText = "x".repeat(150);
+            const [feed] = await parse([item({ title: null, summary: { content: "<p>" + longText + "</p>" } })]);
+
+            expect(feed.title).toBe("x".repeat(100) + "...");
+            expect(feed.title).toHaveLength(103);
+        });
+
+        it("does not truncate a derived title of exactly 100 characters", async () => {
+            const exactText = "y".repeat(100);
+            const [feed] = await parse([item({ title: null, summary: { content: exactText } })]);
+
+            expect(feed.title).toBe(exactText);
+        });
+
+        it("uses '[no title]' when there is neither a title nor a summary", async () => {
+            const [feed] = await parse([item({ title: null, summary: undefined })]);
+
+            expect(feed.title).toBe("[no title]");
+        });
+
+        it("strips the wrapping div from an rtl title and flags the direction", async () => {
+            const [feed] = await parse([item({
+                title: "<div style=\"direction:rtl\">Shalom</div>"
+            })]);
+
+            expect(feed.title).toBe("Shalom");
+            expect(feed.titleDirection).toBe("rtl");
+        });
+
+        it("leaves ltr titles undirected", async () => {
+            const [feed] = await parse([item()]);
+
+            expect(feed.titleDirection).toBeUndefined();
+        });
+    });
+
+    describe("content selection", () => {
+        it("uses the summary by default", async () => {
+            const [feed] = await parse([item({
+                content: { content: "<p>Full content</p>", direction: "ltr" }
+            })]);
+
+            expect(feed.content).toBe("<p>Summary text</p>");
+        });
+
+        it("uses the full content when showFullFeedContent is on", async () => {
+            appGlobal.options.showFullFeedContent = true;
+            const [feed] = await parse([item({
+                content: { content: "<p>Full content</p>", direction: "rtl" }
+            })]);
+
+            expect(feed.content).toBe("<p>Full content</p>");
+            expect(feed.contentDirection).toBe("rtl");
+        });
+
+        it("falls back to the summary when full content is requested but absent", async () => {
+            appGlobal.options.showFullFeedContent = true;
+            const [feed] = await parse([item({ content: undefined })]);
+
+            expect(feed.content).toBe("<p>Summary text</p>");
+        });
+    });
+
+    describe("saved state", () => {
+        it("marks an item saved when it carries the global.saved tag", async () => {
+            const [feed] = await parse([item({ tags: [{ id: "user/u1/tag/global.saved" }] })]);
+
+            expect(feed.isSaved).toBe(true);
+        });
+
+        it("leaves isSaved unset for other tags", async () => {
+            const [feed] = await parse([item({ tags: [{ id: "user/u1/tag/reading-list" }] })]);
+
+            expect(feed.isSaved).toBeUndefined();
+        });
+    });
+
+    describe("engagement", () => {
+        it.each([
+            { engagement: 999, expected: 999, postfix: "", hot: false, onFire: false },
+            // The abbreviation threshold is exclusive, so 1000 stays unabbreviated.
+            { engagement: 1000, expected: 1000, postfix: "", hot: false, onFire: false },
+            { engagement: 1001, expected: 1, postfix: "K", hot: false, onFire: false },
+            { engagement: 4999, expected: 4, postfix: "K", hot: false, onFire: false },
+            { engagement: 5000, expected: 5, postfix: "K", hot: true, onFire: false },
+            { engagement: 99999, expected: 99, postfix: "K", hot: true, onFire: false },
+            { engagement: 100000, expected: 100, postfix: "K", hot: false, onFire: true }
+        ])("formats an engagement of $engagement", async ({ engagement, expected, postfix, hot, onFire }) => {
+            const [feed] = await parse([item({ engagement })]);
+
+            expect(feed.engagement).toBe(expected);
+            expect(feed.engagementPostfix).toBe(postfix);
+            expect(feed.isEngagementHot).toBe(hot);
+            expect(feed.isEngagementOnFire).toBe(onFire);
+        });
+
+        it("shows the engagement badge only for a positive count", async () => {
+            const [zero] = await parse([item({ engagement: 0 })]);
+            const [some] = await parse([item({ engagement: 1 })]);
+
+            expect(zero.showEngagement).toBe(false);
+            expect(some.showEngagement).toBe(true);
+        });
+
+        it("defaults a missing engagement rate to zero", async () => {
+            const [feed] = await parse([item({ engagementRate: undefined })]);
+
+            expect(feed.engagementRate).toBe(0);
+        });
+    });
+
+    describe("dates, categories and thumbnails", () => {
+        it("exposes the crawl time as both a Date and an ISO string", async () => {
+            const crawled = Date.UTC(2024, 0, 15, 12, 0, 0);
+            const [feed] = await parse([item({ crawled })]);
+
+            expect(feed.date).toBeInstanceOf(Date);
+            expect(feed.date.getTime()).toBe(crawled);
+            expect(feed.isoDate).toBe("2024-01-15T12:00:00.000Z");
+        });
+
+        it("leaves the date empty when the item was never crawled", async () => {
+            const [feed] = await parse([item({ crawled: undefined })]);
+
+            expect(feed.isoDate).toBe("");
+            expect(feed.date).toBe("");
+        });
+
+        it("encodes category ids for use in selectors", async () => {
+            const [feed] = await parse([item({
+                categories: [{ id: "user/u1/category/A B", label: "A B" }]
+            })]);
+
+            expect(feed.categories).toEqual([
+                { id: "user/u1/category/A B", encodedId: "user/u1/category/A%20B", label: "A B" }
+            ]);
+        });
+
+        it("returns an empty category list when the item has none", async () => {
+            const [feed] = await parse([item({ categories: undefined })]);
+
+            expect(feed.categories).toEqual([]);
+        });
+
+        it("picks the first thumbnail, or null when there is none", async () => {
+            const [withThumb] = await parse([item({ thumbnail: [{ url: "https://img/1.png" }] })]);
+            const [without] = await parse([item({ thumbnail: [] })]);
+
+            expect(withThumb.thumbnail).toBe("https://img/1.png");
+            expect(without.thumbnail).toBeNull();
+        });
+    });
+
+    it("maps every item in the response", async () => {
+        const feeds = await parse([item({ id: "a" }), item({ id: "b" }), item({ id: "c" })]);
+
+        expect(feeds.map(feed => feed.id)).toEqual(["a", "b", "c"]);
+    });
+});

--- a/test/core.update-feeds.test.js
+++ b/test/core.update-feeds.test.js
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+
+/** A minimal Feedly item; only the fields updateFeeds sorts and dedups on. */
+function entry(id, { crawled = 0, engagementRate = 0, title = id } = {}) {
+    return {
+        id,
+        title,
+        crawled,
+        engagementRate,
+        origin: { htmlUrl: "https://blog.com", streamId: "feed/blog", title: "Blog" },
+        alternate: [{ href: `https://blog.com/${id}` }],
+        categories: []
+    };
+}
+
+describe("updateFeeds", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+    let requestedMethods;
+
+    /**
+     * Stubs the API so each stream id returns its own set of items.
+     * @param {object} streams - map of stream id to item array.
+     */
+    function stubStreams(streams) {
+        requestedMethods = [];
+        appGlobal.options.accessToken = "token";
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method) => {
+                requestedMethods.push(method);
+                if (method === "subscriptions") {
+                    return [];
+                }
+                const streamId = decodeURIComponent(method.replace(/^streams\//, "").replace(/\/contents$/, ""));
+                return { items: streams[streamId] || [] };
+            }
+        };
+    }
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.feedlyUserId = "u1";
+    });
+
+    it("caches the parsed feeds from the global stream", async () => {
+        stubStreams({ "user/u1/category/global.all": [entry("a"), entry("b")] });
+
+        await ctx.updateFeeds(true);
+
+        expect(appGlobal.cachedFeeds.map(feed => feed.id)).toEqual(["a", "b"]);
+    });
+
+    it("persists the cache to local storage", async () => {
+        stubStreams({ "user/u1/category/global.all": [entry("a")] });
+
+        await ctx.updateFeeds(true);
+
+        const stored = await browser.storage.local.get("cachedFeeds");
+        expect(stored.cachedFeeds).toHaveLength(1);
+    });
+
+    it("requests one stream per filter when filtering is enabled", async () => {
+        appGlobal.options.isFiltersEnabled = true;
+        appGlobal.options.filters = ["cat/A", "cat/B"];
+        stubStreams({ "cat/A": [entry("a")], "cat/B": [entry("b")] });
+
+        await ctx.updateFeeds(true);
+
+        expect(requestedMethods).toContain("streams/cat%2FA/contents");
+        expect(requestedMethods).toContain("streams/cat%2FB/contents");
+        expect(appGlobal.cachedFeeds.map(feed => feed.id).sort()).toEqual(["a", "b"]);
+    });
+
+    it("falls back to the global stream when filtering is on but no filter is chosen", async () => {
+        appGlobal.options.isFiltersEnabled = true;
+        appGlobal.options.filters = [];
+        stubStreams({ "user/u1/category/global.all": [entry("a")] });
+
+        await ctx.updateFeeds(true);
+
+        expect(appGlobal.cachedFeeds.map(feed => feed.id)).toEqual(["a"]);
+    });
+
+    /*
+     * The dedup filter drops an entry when a later copy exists, so the *last*
+     * occurrence survives (core.js:665-672). Which stream's copy wins matters,
+     * because the metadata can differ between them.
+     */
+    it("keeps the last copy of an item present in several streams", async () => {
+        appGlobal.options.isFiltersEnabled = true;
+        appGlobal.options.filters = ["cat/A", "cat/B"];
+        appGlobal.options.sortBy = "engagement";
+        stubStreams({
+            "cat/A": [entry("dupe", { title: "from A" })],
+            "cat/B": [entry("dupe", { title: "from B" })]
+        });
+
+        await ctx.updateFeeds(true);
+
+        expect(appGlobal.cachedFeeds).toHaveLength(1);
+        expect(appGlobal.cachedFeeds[0].title).toBe("from B");
+    });
+
+    describe("sorting", () => {
+        const older = Date.UTC(2024, 0, 1);
+        const newer = Date.UTC(2024, 6, 1);
+
+        it("puts the newest first by default", async () => {
+            appGlobal.options.sortBy = "newest";
+            stubStreams({
+                "user/u1/category/global.all": [
+                    entry("old", { crawled: older }),
+                    entry("new", { crawled: newer })
+                ]
+            });
+
+            await ctx.updateFeeds(true);
+
+            expect(appGlobal.cachedFeeds.map(feed => feed.id)).toEqual(["new", "old"]);
+        });
+
+        it("puts the oldest first when asked", async () => {
+            appGlobal.options.sortBy = "oldest";
+            stubStreams({
+                "user/u1/category/global.all": [
+                    entry("new", { crawled: newer }),
+                    entry("old", { crawled: older })
+                ]
+            });
+
+            await ctx.updateFeeds(true);
+
+            expect(appGlobal.cachedFeeds.map(feed => feed.id)).toEqual(["old", "new"]);
+        });
+
+        it("falls back to engagement rate for any other sort order", async () => {
+            appGlobal.options.sortBy = "engagement";
+            stubStreams({
+                "user/u1/category/global.all": [
+                    entry("low", { engagementRate: 0.5 }),
+                    entry("high", { engagementRate: 9.5 }),
+                    entry("mid", { engagementRate: 3 })
+                ]
+            });
+
+            await ctx.updateFeeds(true);
+
+            expect(appGlobal.cachedFeeds.map(feed => feed.id)).toEqual(["high", "mid", "low"]);
+        });
+    });
+
+    it("truncates the cache to the configured maximum after sorting", async () => {
+        appGlobal.options.maxNumberOfFeeds = 2;
+        appGlobal.options.sortBy = "newest";
+        stubStreams({
+            "user/u1/category/global.all": [
+                entry("a", { crawled: 1 }),
+                entry("b", { crawled: 3 }),
+                entry("c", { crawled: 2 })
+            ]
+        });
+
+        await ctx.updateFeeds(true);
+
+        expect(appGlobal.cachedFeeds.map(feed => feed.id)).toEqual(["b", "c"]);
+    });
+
+    it("restores the previous cache when a stream request fails", async () => {
+        appGlobal.cachedFeeds = [{ id: "previously-cached" }];
+        appGlobal.options.accessToken = "token";
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => {
+                throw { status: 500 };
+            }
+        };
+
+        await ctx.updateFeeds(true);
+
+        expect(appGlobal.cachedFeeds).toEqual([{ id: "previously-cached" }]);
+        expect(await browser.storage.local.get("cachedFeeds")).toEqual({});
+    });
+
+    it("shows no notifications during a silent update", async () => {
+        appGlobal.options.showDesktopNotifications = true;
+        stubStreams({ "user/u1/category/global.all": [entry("a")] });
+
+        await ctx.updateFeeds(true);
+
+        expect(browser._calls.notificationsCreated).toEqual([]);
+    });
+
+    it("notifies about new feeds during a normal update", async () => {
+        appGlobal.options.showDesktopNotifications = true;
+        appGlobal.options.maxNotificationsCount = 5;
+        stubStreams({
+            "user/u1/category/global.all": [entry("a", { crawled: Date.now() })]
+        });
+
+        await ctx.updateFeeds(false);
+
+        expect(browser._calls.notificationsCreated).toHaveLength(1);
+    });
+});
+
+describe("getFeeds", () => {
+    let ctx;
+    let appGlobal;
+
+    beforeEach(() => {
+        ({ ctx, appGlobal } = loadCore());
+        appGlobal.options.accessToken = "token";
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => ({ items: [] })
+        };
+    });
+
+    it("serves a warm cache without hitting the network", async () => {
+        let requests = 0;
+        appGlobal.cachedFeeds = [{ id: "cached" }];
+        appGlobal.feedlyApiClient.request = async () => {
+            requests++;
+            return { items: [] };
+        };
+
+        const result = await ctx.getFeeds(false);
+
+        expect(result.feeds).toEqual([{ id: "cached" }]);
+        expect(requests).toBe(0);
+    });
+
+    it("returns a copy so callers cannot mutate the cache", async () => {
+        appGlobal.cachedFeeds = [{ id: "cached" }];
+
+        const result = await ctx.getFeeds(false);
+        result.feeds.push({ id: "injected" });
+
+        expect(appGlobal.cachedFeeds).toHaveLength(1);
+    });
+
+    it("refetches when an update is forced", async () => {
+        let requests = 0;
+        appGlobal.cachedFeeds = [{ id: "cached" }];
+        appGlobal.feedlyApiClient.request = async () => {
+            requests++;
+            return { items: [] };
+        };
+
+        await ctx.getFeeds(true);
+
+        expect(requests).toBeGreaterThan(0);
+    });
+});

--- a/test/feedly.api.test.js
+++ b/test/feedly.api.test.js
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { loadApiClient } from "./helpers/load-core.js";
+
+/** Builds a fetch stub that records its calls and returns a canned response. */
+function fetchStub({ status = 200, body = {}, json } = {}) {
+    const calls = [];
+    const stub = async (url, parameters) => {
+        calls.push({ url, parameters });
+        return {
+            status,
+            json: json || (async () => body)
+        };
+    };
+    stub.calls = calls;
+    return stub;
+}
+
+describe("FeedlyApiClient", () => {
+    describe("getMethodUrl", () => {
+        it("returns an empty string when no method is given", () => {
+            const { FeedlyApiClient } = loadApiClient();
+
+            expect(new FeedlyApiClient().getMethodUrl()).toBe("");
+        });
+
+        it("builds an absolute v3 url carrying the extension version", () => {
+            const { FeedlyApiClient } = loadApiClient({ version: "3.2.0" });
+
+            expect(new FeedlyApiClient().getMethodUrl("markers/counts"))
+                .toBe("https://cloud.feedly.com/v3/markers/counts?av=c3.2.0");
+        });
+
+        it("appends every parameter, keeping the trailing separator before av", () => {
+            const { FeedlyApiClient } = loadApiClient({ version: "3.2.0" });
+
+            expect(new FeedlyApiClient().getMethodUrl("streams/contents", { count: 20, ranked: "newest" }))
+                .toBe("https://cloud.feedly.com/v3/streams/contents?count=20&ranked=newest&av=c3.2.0");
+        });
+
+        // KNOWN BEHAVIOUR: parameters are interpolated raw (feedly.api.js:19).
+        // Callers encode ids themselves before passing them in.
+        it("does not url-encode parameter values", () => {
+            const { FeedlyApiClient } = loadApiClient({ version: "3.2.0" });
+
+            expect(new FeedlyApiClient().getMethodUrl("search", { q: "a&b=c" }))
+                .toBe("https://cloud.feedly.com/v3/search?q=a&b=c&av=c3.2.0");
+        });
+
+        /*
+         * The `av` prefix is set inside `// @if BROWSER=...` blocks. Those are
+         * comments, so this assertion only means anything because the loader
+         * preprocesses the source the way the Grunt build does -- on raw src/
+         * all three branches run and firefox always wins.
+         */
+        it.each([
+            ["chrome", "c"],
+            ["opera", "o"],
+            ["firefox", "f"]
+        ])("uses the %s analytics prefix '%s'", (targetBrowser, prefix) => {
+            const { FeedlyApiClient } = loadApiClient({ targetBrowser, version: "3.2.0" });
+
+            expect(new FeedlyApiClient().getMethodUrl("profile"))
+                .toBe(`https://cloud.feedly.com/v3/profile?av=${prefix}3.2.0`);
+        });
+    });
+
+    describe("request", () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("appends a cache-busting timestamp to GET requests", async () => {
+            const fetch = fetchStub();
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await new FeedlyApiClient("token").request("markers/counts", {});
+
+            expect(fetch.calls[0].url).toContain(`&ck=${Date.now()}`);
+        });
+
+        it("does not cache-bust non-GET requests", async () => {
+            const fetch = fetchStub();
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await new FeedlyApiClient("token").request("markers", { method: "POST" });
+
+            expect(fetch.calls[0].url).not.toContain("ck=");
+            expect(fetch.calls[0].parameters.method).toBe("POST");
+        });
+
+        it("sends the access token as an OAuth header", async () => {
+            const fetch = fetchStub();
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await new FeedlyApiClient("secret-token").request("profile", {});
+
+            expect(fetch.calls[0].parameters.headers.Authorization).toBe("OAuth secret-token");
+        });
+
+        it("omits the header when there is no token", async () => {
+            const fetch = fetchStub();
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await new FeedlyApiClient().request("profile", {});
+
+            expect(fetch.calls[0].parameters.headers).toEqual({});
+        });
+
+        // The token-refresh call must not present the expired token.
+        it("omits the header when authentication is explicitly skipped", async () => {
+            const fetch = fetchStub();
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await new FeedlyApiClient("expired").request("auth/token", {
+                method: "POST",
+                skipAuthentication: true
+            });
+
+            expect(fetch.calls[0].parameters.headers).toEqual({});
+        });
+
+        it("serialises the body as JSON", async () => {
+            const fetch = fetchStub();
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await new FeedlyApiClient("token").request("markers", {
+                method: "POST",
+                body: { action: "markAsRead", entryIds: ["a", "b"] }
+            });
+
+            expect(fetch.calls[0].parameters.body)
+                .toBe("{\"action\":\"markAsRead\",\"entryIds\":[\"a\",\"b\"]}");
+        });
+
+        it("resolves with the parsed body on 200", async () => {
+            const fetch = fetchStub({ body: { id: "user-1" } });
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await expect(new FeedlyApiClient("token").request("profile", {}))
+                .resolves.toEqual({ id: "user-1" });
+        });
+
+        it("resolves with an empty object when a 200 body is not JSON", async () => {
+            const fetch = fetchStub({
+                json: async () => {
+                    throw new SyntaxError("Unexpected token");
+                }
+            });
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await expect(new FeedlyApiClient("token").request("markers", { method: "POST" }))
+                .resolves.toEqual({});
+        });
+
+        /*
+         * Rejecting with the raw response rather than an Error is load-bearing:
+         * apiRequestWrapper and refreshAccessToken both branch on `.status`.
+         */
+        it.each([401, 403, 500])("rejects with the raw response object on %i", async (status) => {
+            const fetch = fetchStub({ status });
+            const { FeedlyApiClient } = loadApiClient({ fetch });
+
+            await expect(new FeedlyApiClient("token").request("profile", {}))
+                .rejects.toHaveProperty("status", status);
+        });
+    });
+});

--- a/test/fixtures/feedly-responses.js
+++ b/test/fixtures/feedly-responses.js
@@ -15,7 +15,7 @@ const SUBSCRIPTIONS = [
 
 /** Builds a single Feedly stream item, overridable field by field. */
 function item(overrides = {}) {
-    return Object.assign({
+    return {
         id: "item-1",
         title: "A post title",
         origin: {
@@ -28,8 +28,9 @@ function item(overrides = {}) {
         engagementRate: 1.5,
         alternate: [{ href: "https://blog-a.com/posts/1" }],
         categories: [{ id: "user/u1/category/Tech", label: "Tech" }],
-        summary: { content: "<p>Summary text</p>", direction: "ltr" }
-    }, overrides);
+        summary: { content: "<p>Summary text</p>", direction: "ltr" },
+        ...overrides
+    };
 }
 
 /** Wraps items in the stream contents envelope. */

--- a/test/fixtures/feedly-responses.js
+++ b/test/fixtures/feedly-responses.js
@@ -1,0 +1,40 @@
+/** Canned Feedly API payloads shared by the unit suites. */
+
+const SUBSCRIPTIONS = [
+    {
+        id: "feed/http://blog-a.com/rss",
+        title: "Blog A (renamed by user)",
+        categories: [{ id: "user/u1/category/Tech", label: "Tech" }]
+    },
+    {
+        id: "feed/http://blog-b.com/rss",
+        title: "Blog B",
+        categories: [{ id: "user/u1/category/News", label: "News" }]
+    }
+];
+
+/** Builds a single Feedly stream item, overridable field by field. */
+function item(overrides = {}) {
+    return Object.assign({
+        id: "item-1",
+        title: "A post title",
+        origin: {
+            htmlUrl: "https://blog-a.com/blog",
+            streamId: "feed/http://blog-a.com/rss",
+            title: "Blog A original title"
+        },
+        crawled: Date.UTC(2024, 0, 15, 12, 0, 0),
+        engagement: 10,
+        engagementRate: 1.5,
+        alternate: [{ href: "https://blog-a.com/posts/1" }],
+        categories: [{ id: "user/u1/category/Tech", label: "Tech" }],
+        summary: { content: "<p>Summary text</p>", direction: "ltr" }
+    }, overrides);
+}
+
+/** Wraps items in the stream contents envelope. */
+function stream(items) {
+    return { items };
+}
+
+export { SUBSCRIPTIONS, item, stream };

--- a/test/helpers/browser-mock.js
+++ b/test/helpers/browser-mock.js
@@ -1,0 +1,219 @@
+/**
+ * A hand-rolled stub of the promise-based `webextension-polyfill` API surface.
+ *
+ * Deliberately not `sinon-chrome`: that package models the callback-style
+ * `chrome.*` API, whereas this extension is written against the promise-based
+ * polyfill. Only the surfaces actually used by src/scripts/*.js are stubbed --
+ * see `grep -oh "browser\.[a-zA-Z]*\.[a-zA-Z]*" src/scripts/*.js`.
+ */
+
+/* Records its listeners so tests can fire events by hand. */
+function createEvent(name, registry) {
+    const listeners = [];
+    registry[name] = listeners;
+    return {
+        addListener(fn) {
+            listeners.push(fn);
+        },
+        removeListener(fn) {
+            const index = listeners.indexOf(fn);
+            if (index !== -1) {
+                listeners.splice(index, 1);
+            }
+        },
+        hasListener(fn) {
+            return listeners.indexOf(fn) !== -1;
+        },
+        /* Test helper: invoke every registered listener and await them all. */
+        async trigger(...args) {
+            return Promise.all(listeners.map(fn => fn(...args)));
+        }
+    };
+}
+
+/**
+ * A storage area backed by a plain object, honouring the three `get` shapes
+ * core.js actually calls: `get(null)`, `get("key")` and `get(["a", "b"])`.
+ */
+function createStorageArea(initial) {
+    const data = Object.assign({}, initial);
+
+    return {
+        /* Exposed so tests can seed or assert without going through promises. */
+        _data: data,
+        async get(keys) {
+            if (keys === null || keys === undefined) {
+                return Object.assign({}, data);
+            }
+            const wanted = Array.isArray(keys) ? keys : [keys];
+            const result = {};
+            for (const key of wanted) {
+                if (Object.prototype.hasOwnProperty.call(data, key)) {
+                    result[key] = data[key];
+                }
+            }
+            return result;
+        },
+        async set(items) {
+            Object.assign(data, items);
+        },
+        async remove(keys) {
+            const unwanted = Array.isArray(keys) ? keys : [keys];
+            for (const key of unwanted) {
+                delete data[key];
+            }
+        },
+        async clear() {
+            for (const key of Object.keys(data)) {
+                delete data[key];
+            }
+        }
+    };
+}
+
+/**
+ * Builds a fresh `browser` mock.
+ *
+ * @param {object} [overrides] - `{ version, os, storage: { local, sync, session } }`
+ * @returns {object} the mock, with `_events` (listener registry) and `_calls`
+ *                   (recorded mutating calls) attached for assertions.
+ */
+function createBrowserMock(overrides) {
+    const options = overrides || {};
+    const events = {};
+    const calls = {
+        setBadgeText: [],
+        setIcon: [],
+        setPopup: [],
+        setBadgeBackgroundColor: [],
+        alarmsCreated: [],
+        alarmsCleared: [],
+        notificationsCreated: [],
+        notificationsCleared: [],
+        tabsCreated: [],
+        tabsUpdated: [],
+        windowsCreated: [],
+        messagesSent: []
+    };
+
+    let badgeText = "";
+
+    const browser = {
+        _events: events,
+        _calls: calls,
+
+        runtime: {
+            getManifest: () => ({ version: options.version || "3.2.0" }),
+            getPlatformInfo: async () => ({ os: options.os || "win" }),
+            sendMessage: async (message) => {
+                calls.messagesSent.push(message);
+                return undefined;
+            },
+            onInstalled: createEvent("runtime.onInstalled", events),
+            onStartup: createEvent("runtime.onStartup", events),
+            onMessage: createEvent("runtime.onMessage", events)
+        },
+
+        storage: {
+            local: createStorageArea(options.storage && options.storage.local),
+            sync: createStorageArea(options.storage && options.storage.sync),
+            session: createStorageArea(options.storage && options.storage.session),
+            onChanged: createEvent("storage.onChanged", events)
+        },
+
+        tabs: {
+            create: async (props) => {
+                calls.tabsCreated.push(props);
+                return { id: calls.tabsCreated.length, url: props.url };
+            },
+            update: async (tabId, props) => {
+                calls.tabsUpdated.push({ tabId, props });
+                return { id: tabId, url: props.url };
+            },
+            query: async () => [],
+            reload: async () => undefined,
+            onRemoved: createEvent("tabs.onRemoved", events),
+            onUpdated: createEvent("tabs.onUpdated", events)
+        },
+
+        windows: {
+            create: async (props) => {
+                calls.windowsCreated.push(props);
+                return { id: calls.windowsCreated.length };
+            },
+            getAll: async () => []
+        },
+
+        webRequest: {
+            onCompleted: createEvent("webRequest.onCompleted", events)
+        },
+
+        action: {
+            getBadgeText: async () => badgeText,
+            setBadgeText: async (details) => {
+                badgeText = details.text;
+                calls.setBadgeText.push(details.text);
+            },
+            setIcon: async (details) => {
+                calls.setIcon.push(details.path);
+            },
+            setPopup: async (details) => {
+                calls.setPopup.push(details.popup);
+            },
+            setBadgeBackgroundColor: async (details) => {
+                calls.setBadgeBackgroundColor.push(details.color);
+            },
+            onClicked: createEvent("action.onClicked", events)
+        },
+
+        alarms: {
+            create: (name, info) => {
+                calls.alarmsCreated.push({ name, info });
+            },
+            clear: (name) => {
+                calls.alarmsCleared.push(name);
+            },
+            onAlarm: createEvent("alarms.onAlarm", events)
+        },
+
+        notifications: {
+            create: (id, notification) => {
+                calls.notificationsCreated.push({ id, notification });
+            },
+            clear: (id) => {
+                calls.notificationsCleared.push(id);
+            },
+            onClicked: createEvent("notifications.onClicked", events),
+            onButtonClicked: createEvent("notifications.onButtonClicked", events)
+        },
+
+        i18n: {
+            getMessage: (key) => key,
+            getUILanguage: () => options.uiLanguage || "en"
+        },
+
+        permissions: {
+            contains: async () => options.hasAllSitesPermission !== false,
+            request: async () => options.grantPermission !== false
+        }
+    };
+
+    /* Chromium-only surfaces. Omitted when simulating Firefox. */
+    if (options.sidePanel !== false) {
+        browser.sidePanel = {
+            setOptions: async () => undefined,
+            setPanelBehavior: async () => undefined,
+            open: async () => undefined
+        };
+    }
+
+    if (options.sidebarAction) {
+        browser.sidebarAction = {
+            isOpen: async () => Boolean(options.sidebarOpen)
+        };
+    }
+
+    return browser;
+}
+
+export { createBrowserMock, createStorageArea, createEvent };

--- a/test/helpers/browser-mock.js
+++ b/test/helpers/browser-mock.js
@@ -22,7 +22,7 @@ function createEvent(name, registry) {
             }
         },
         hasListener(fn) {
-            return listeners.indexOf(fn) !== -1;
+            return listeners.includes(fn);
         },
         /* Test helper: invoke every registered listener and await them all. */
         async trigger(...args) {
@@ -36,19 +36,19 @@ function createEvent(name, registry) {
  * core.js actually calls: `get(null)`, `get("key")` and `get(["a", "b"])`.
  */
 function createStorageArea(initial) {
-    const data = Object.assign({}, initial);
+    const data = { ...initial };
 
     return {
         /* Exposed so tests can seed or assert without going through promises. */
         _data: data,
         async get(keys) {
             if (keys === null || keys === undefined) {
-                return Object.assign({}, data);
+                return { ...data };
             }
             const wanted = Array.isArray(keys) ? keys : [keys];
             const result = {};
             for (const key of wanted) {
-                if (Object.prototype.hasOwnProperty.call(data, key)) {
+                if (Object.hasOwn(data, key)) {
                     result[key] = data[key];
                 }
             }
@@ -115,9 +115,9 @@ function createBrowserMock(overrides) {
         },
 
         storage: {
-            local: createStorageArea(options.storage && options.storage.local),
-            sync: createStorageArea(options.storage && options.storage.sync),
-            session: createStorageArea(options.storage && options.storage.session),
+            local: createStorageArea(options.storage?.local),
+            sync: createStorageArea(options.storage?.sync),
+            session: createStorageArea(options.storage?.session),
             onChanged: createEvent("storage.onChanged", events)
         },
 

--- a/test/helpers/load-core.js
+++ b/test/helpers/load-core.js
@@ -23,6 +23,10 @@ function compileScript(name, targetBrowser) {
         const source = readFileSync(filename, "utf8");
         // Line-preserving, so stack traces and coverage point at the real file.
         const processed = targetBrowser ? preprocessPreservingLines(source, targetBrowser) : source;
+        // NOSONAR - compiling this repository's own src/scripts files is the
+        // entire purpose of the loader; the input is a checked-in source file,
+        // never user input, and it runs in an isolated context under the test
+        // runner only.
         scriptCache.set(key, new Script(processed, { filename }));
     }
     return scriptCache.get(key);
@@ -34,7 +38,7 @@ function compileScript(name, targetBrowser) {
  * follow-up script in the *same* context can still see them, which is how
  * `FeedlyApiClient` gets published to the test.
  */
-const EXPOSE_LEXICALS = new Script(
+const EXPOSE_LEXICALS = new Script( // NOSONAR - fixed literal, no dynamic input
     "globalThis.FeedlyApiClient = FeedlyApiClient;",
     { filename: "expose-lexicals.js" }
 );

--- a/test/helpers/load-core.js
+++ b/test/helpers/load-core.js
@@ -1,0 +1,179 @@
+import { readFileSync } from "node:fs";
+import { createContext, Script } from "node:vm";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { preprocessPreservingLines } from "./preprocess.js";
+import { createBrowserMock } from "./browser-mock.js";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const scriptsDir = path.join(projectRoot, "src", "scripts");
+
+/**
+ * Compiling core.js is the only expensive part of loading, so scripts are
+ * compiled once per (file, browser) pair and then run into a fresh context for
+ * each test.
+ */
+const scriptCache = new Map();
+
+function compileScript(name, targetBrowser) {
+    const key = `${name}:${targetBrowser}`;
+    if (!scriptCache.has(key)) {
+        const filename = path.join(scriptsDir, name);
+        const source = readFileSync(filename, "utf8");
+        // Line-preserving, so stack traces and coverage point at the real file.
+        const processed = targetBrowser ? preprocessPreservingLines(source, targetBrowser) : source;
+        scriptCache.set(key, new Script(processed, { filename }));
+    }
+    return scriptCache.get(key);
+}
+
+/**
+ * `let` and `const` bindings live in the realm's global lexical environment
+ * rather than on the global object, so they never appear on the context. A
+ * follow-up script in the *same* context can still see them, which is how
+ * `FeedlyApiClient` gets published to the test.
+ */
+const EXPOSE_LEXICALS = new Script(
+    "globalThis.FeedlyApiClient = FeedlyApiClient;",
+    { filename: "expose-lexicals.js" }
+);
+
+function createSandbox(browser, options) {
+    return {
+        browser,
+        chrome: browser,
+        console,
+        fetch: options.fetch || (async () => {
+            throw new Error("Unexpected fetch call: pass a stub via loadCore({ fetch })");
+        }),
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        // Injected from the host realm so `toBeInstanceOf(Date)` holds in
+        // assertions. Other intrinsics stay realm-local -- see the cross-realm
+        // note below.
+        Date,
+        URL,
+        URLSearchParams,
+        Audio: options.Audio
+    };
+}
+
+/**
+ * Evaluates feedly.api.js and core.js in a fresh V8 context and returns the
+ * globals they define.
+ *
+ * Why a `vm` context at all: the scripts export nothing. They are classic
+ * browser globals joined at runtime by `importScripts()`. A `vm` context
+ * exposes top-level `function` declarations and `var` as properties of its
+ * global object, which is what makes `appGlobal` and every core.js function
+ * reachable without touching src/.
+ *
+ * Source is preprocessed by default. Raw src/ is actively misleading: the
+ * `// @if BROWSER=...` directives are comments, so every branch executes and
+ * the last one wins -- unpreprocessed, getMethodUrl always reports firefox.
+ *
+ * CROSS-REALM GOTCHAS. The context has its own intrinsics, so:
+ *   - `expect(x).toBeInstanceOf(Array)` fails. Use `Array.isArray(x)`, which is
+ *     cross-realm safe, or the structural `toEqual`.
+ *   - `expect(p).rejects.toThrow(Error)` fails. Assert on shape instead:
+ *     `.rejects.toMatchObject({ message })` or `.rejects.toHaveProperty("status", 401)`.
+ *   - `Date` is injected from the host realm, so `toBeInstanceOf(Date)` does work.
+ *
+ * @param {object} [options]
+ * @param {string|null} [options.targetBrowser="chrome"] - preprocess target, or
+ *        null to evaluate raw source.
+ * @param {object} [options.storage] - seed data for `{ local, sync, session }`.
+ * @param {Function} [options.fetch] - stub for the global `fetch`.
+ * @returns {{ctx: object, browser: object, appGlobal: object, FeedlyApiClient: Function}}
+ */
+function loadCore(options = {}) {
+    const targetBrowser = options.targetBrowser === undefined ? "chrome" : options.targetBrowser;
+    const browser = options.browser || createBrowserMock(options);
+
+    const ctx = createContext(createSandbox(browser, options));
+
+    // Separate scripts, each named after its real file, so failures point at
+    // the right source. The second script sees the first script's `let`.
+    compileScript("feedly.api.js", targetBrowser).runInContext(ctx);
+    compileScript("core.js", targetBrowser).runInContext(ctx);
+    EXPOSE_LEXICALS.runInContext(ctx);
+
+    return {
+        ctx,
+        browser,
+        appGlobal: ctx.appGlobal,
+        FeedlyApiClient: ctx.FeedlyApiClient
+    };
+}
+
+/**
+ * Loads the MV3 service worker entry point on top of the core scripts.
+ *
+ * background.js pulls its dependencies in with `importScripts`, which exists
+ * only in a worker, so the loader supplies it and ignores the vendor polyfill
+ * (the browser mock already stands in for it).
+ *
+ * Loading has side effects by design: `ensureInitialized()` runs eagerly, so
+ * options are read and the schedule started before this returns.
+ *
+ * @returns {{ctx, browser, appGlobal, onMessage: Function}} `onMessage`
+ *          dispatches to the registered runtime.onMessage handler.
+ */
+function loadBackground(options = {}) {
+    const targetBrowser = options.targetBrowser === undefined ? "chrome" : options.targetBrowser;
+    const browser = options.browser || createBrowserMock(options);
+
+    const sandbox = createSandbox(browser, options);
+    sandbox.importScripts = (...names) => {
+        for (const name of names) {
+            // The polyfill is what provides `browser`; the mock already does.
+            if (name.includes("browser-polyfill")) {
+                continue;
+            }
+            compileScript(path.basename(name), targetBrowser).runInContext(ctx);
+        }
+        EXPOSE_LEXICALS.runInContext(ctx);
+    };
+
+    const ctx = createContext(sandbox);
+    compileScript("background.js", targetBrowser).runInContext(ctx);
+
+    const listeners = browser._events["runtime.onMessage"];
+
+    return {
+        ctx,
+        browser,
+        appGlobal: ctx.appGlobal,
+        onMessage: (message, sender) => listeners[0](message, sender || {}),
+        /*
+         * Boot is asynchronous and `startSchedule` fires updateCounter and
+         * updateFeeds without awaiting them, so tests must let both settle
+         * before touching the caches -- otherwise the boot fetch lands mid-test
+         * and overwrites whatever the test just seeded.
+         */
+        ready: async () => {
+            await ctx.ensureInitialized();
+            await new Promise(resolve => setTimeout(resolve, 0));
+        }
+    };
+}
+
+/**
+ * Evaluates feedly.api.js alone, for tests that only need the HTTP client.
+ */
+function loadApiClient(options = {}) {
+    const targetBrowser = options.targetBrowser === undefined ? "chrome" : options.targetBrowser;
+    const browser = options.browser || createBrowserMock(options);
+
+    const ctx = createContext(createSandbox(browser, options));
+
+    compileScript("feedly.api.js", targetBrowser).runInContext(ctx);
+    EXPOSE_LEXICALS.runInContext(ctx);
+
+    return { ctx, browser, FeedlyApiClient: ctx.FeedlyApiClient };
+}
+
+export { loadCore, loadBackground, loadApiClient, projectRoot, scriptsDir };

--- a/test/helpers/load-core.js
+++ b/test/helpers/load-core.js
@@ -23,11 +23,13 @@ function compileScript(name, targetBrowser) {
         const source = readFileSync(filename, "utf8");
         // Line-preserving, so stack traces and coverage point at the real file.
         const processed = targetBrowser ? preprocessPreservingLines(source, targetBrowser) : source;
-        // NOSONAR - compiling this repository's own src/scripts files is the
-        // entire purpose of the loader; the input is a checked-in source file,
-        // never user input, and it runs in an isolated context under the test
-        // runner only.
-        scriptCache.set(key, new Script(processed, { filename }));
+        /*
+         * Compiling this repository's own src/scripts files is the entire
+         * purpose of the loader: the input is a checked-in source file, never
+         * user input, and it runs in an isolated context under the test runner
+         * only. Suppression must sit on the reported line itself.
+         */
+        scriptCache.set(key, new Script(processed, { filename })); // NOSONAR
     }
     return scriptCache.get(key);
 }

--- a/test/helpers/load-page.js
+++ b/test/helpers/load-page.js
@@ -1,0 +1,133 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { preprocessPreservingLines } from "./preprocess.js";
+import { createBrowserMock } from "./browser-mock.js";
+import { projectRoot } from "./load-core.js";
+
+/**
+ * Loads popup.js / options.js into the jsdom realm.
+ *
+ * These two cannot use the `vm` loader: they need a real DOM and the real
+ * jQuery, Mustache and DOMPurify builds. The page markup is installed into the
+ * jsdom document and the script is evaluated with indirect eval.
+ *
+ * IMPORTANT: both files open with `"use strict"`, and declarations in strict
+ * eval code stay in the eval's own scope -- nothing reaches the global object,
+ * not even `var` and `function`. So every symbol a test needs must be named in
+ * `expose`, and the loader appends a trailer inside the same eval to publish
+ * them. Accessors rather than values, so reassignment inside the script (such
+ * as popup.js's `options`) stays visible.
+ *
+ * Keep assertions here to pure logic. jQuery's `:visible`, `slideToggle` and
+ * `fadeOut` behave poorly under jsdom; DOM behaviour belongs in the Playwright
+ * suite.
+ */
+
+const EXPORTS_GLOBAL = "__pageExports";
+
+/** Installs a page's markup, minus its script tags, into the jsdom document. */
+function installMarkup(pageName) {
+    const html = readFileSync(path.join(projectRoot, "src", pageName), "utf8");
+    const parsed = new DOMParser().parseFromString(html, "text/html");
+
+    // The real vendor bundles live in build/, and jsdom would try to fetch them.
+    parsed.querySelectorAll("script[src]").forEach(node => node.remove());
+
+    document.replaceChild(document.importNode(parsed.documentElement, true), document.documentElement);
+}
+
+/**
+ * jsdom implements no matchMedia, and setTheme() calls it unconditionally.
+ * @param {boolean} prefersDark - what the media query should report.
+ * @returns {Function[]} the change listeners the page registers.
+ */
+function stubMatchMedia(prefersDark) {
+    const listeners = [];
+    window.matchMedia = (query) => ({
+        matches: Boolean(prefersDark),
+        media: query,
+        addEventListener: (event, handler) => listeners.push(handler),
+        removeEventListener: () => {},
+        addListener: (handler) => listeners.push(handler),
+        removeListener: () => {}
+    });
+    return listeners;
+}
+
+/** Reads a script from src/scripts and preprocesses it for chrome. */
+function readPageScript(name) {
+    return preprocessPreservingLines(
+        readFileSync(path.join(projectRoot, "src", "scripts", name), "utf8"),
+        "chrome"
+    );
+}
+
+/** Trailer that publishes named bindings out of a strict eval. */
+function exportTrailer(target, names) {
+    if (!names.length) {
+        return "";
+    }
+    const accessors = names.map(name => `get ${name}() { return ${name}; }`).join(", ");
+    return `\n;globalThis.${target} = { ${accessors} };`;
+}
+
+/**
+ * @param {object} options
+ * @param {string} options.script - file name under src/scripts.
+ * @param {string} options.page - file name under src/.
+ * @param {string[]} options.expose - symbols the test needs out of the script.
+ * @param {Array<{script: string, expose: string[]}>} [options.dependencies] -
+ *        scripts the page's own <script> tags load first.
+ * @param {boolean} [options.prefersDark]
+ * @returns {Promise<{page: object, browser: object, $: Function, themeListeners: Function[]}>}
+ */
+async function loadPage({
+    script,
+    page,
+    expose = [],
+    dependencies = [],
+    prefersDark = false,
+    ...mockOptions
+}) {
+    installMarkup(page);
+    const themeListeners = stubMatchMedia(prefersDark);
+
+    // jsdom's alert() only logs "not implemented"; saveOptions calls it.
+    window.alert = () => {};
+
+    const browser = mockOptions.browser || createBrowserMock(mockOptions);
+    globalThis.browser = browser;
+    globalThis.chrome = browser;
+
+    // Bind the real libraries to the jsdom window, exactly as the pages do.
+    const { default: jQuery } = await import("jquery");
+    const { default: Mustache } = await import("mustache");
+    const { default: DOMPurify } = await import("dompurify");
+    const timeago = await import("timeago.js");
+
+    globalThis.$ = jQuery;
+    globalThis.jQuery = jQuery;
+    globalThis.Mustache = Mustache;
+    globalThis.DOMPurify = DOMPurify;
+    globalThis.timeago = timeago;
+
+    for (const dependency of dependencies) {
+        (0, eval)(readPageScript(dependency.script) + exportTrailer("__dependency", dependency.expose));
+        // Dependencies are consumed as bare globals by the page script.
+        for (const name of dependency.expose) {
+            globalThis[name] = globalThis.__dependency[name];
+        }
+    }
+
+    (0, eval)(readPageScript(script) + exportTrailer(EXPORTS_GLOBAL, expose));
+
+    return {
+        page: globalThis[EXPORTS_GLOBAL] || {},
+        browser,
+        $: jQuery,
+        themeListeners
+    };
+}
+
+export { loadPage };

--- a/test/helpers/preprocess.js
+++ b/test/helpers/preprocess.js
@@ -16,8 +16,11 @@
  * directive that this simplified parser cannot handle fails loudly.
  */
 
-const IF_DIRECTIVE = /^\s*(?:\/\/|<!--)\s*@if\s+BROWSER\s*(!?)=\s*'([^']*)'\s*(?:-->)?\s*$/;
-const ENDIF_DIRECTIVE = /^\s*(?:\/\/|<!--)\s*@endif\s*(?:-->)?\s*$/;
+// The trailing `-->` is folded inside its optional group rather than sitting
+// between two `\s*` runs, so there is no ambiguity for the engine to backtrack
+// over and matching stays linear.
+const IF_DIRECTIVE = /^\s*(?:\/\/|<!--)\s*@if\s+BROWSER\s*(!?)=\s*'([^']*)'\s*(?:-->\s*)?$/;
+const ENDIF_DIRECTIVE = /^\s*(?:\/\/|<!--)\s*@endif\s*(?:-->\s*)?$/;
 
 /**
  * @param {string} source - file contents.

--- a/test/helpers/preprocess.js
+++ b/test/helpers/preprocess.js
@@ -1,0 +1,65 @@
+/**
+ * A line-preserving stand-in for the `preprocess` package used by grunt-preprocess.
+ *
+ * The upstream package *removes* the lines it strips, which shifts every line
+ * number below a directive (core.js goes from 1158 to ~1141 lines). That would
+ * misalign v8 coverage and every stack trace against the real src/ files, so
+ * this version blanks lines instead of deleting them. Blank lines are valid in
+ * JS, JSON and HTML alike.
+ *
+ * The directive grammar in this repo is only three forms, with no nesting and
+ * no @else -- verified with:
+ *   grep -rn "@if\|@endif\|@else" src/
+ *
+ * `test/preprocess.test.js` pins this implementation against the real
+ * `preprocess` package for every source file and browser target, so any future
+ * directive that this simplified parser cannot handle fails loudly.
+ */
+
+const IF_DIRECTIVE = /^\s*(?:\/\/|<!--)\s*@if\s+BROWSER\s*(!?)=\s*'([^']*)'\s*(?:-->)?\s*$/;
+const ENDIF_DIRECTIVE = /^\s*(?:\/\/|<!--)\s*@endif\s*(?:-->)?\s*$/;
+
+/**
+ * @param {string} source - file contents.
+ * @param {string} targetBrowser - the BROWSER value to resolve against.
+ * @returns {string} source with inactive branches blanked out, line count intact.
+ */
+function preprocessPreservingLines(source, targetBrowser) {
+    const lines = source.split("\n");
+    const output = [];
+    // Stack of booleans: is the branch we are currently inside active?
+    const branches = [];
+
+    const isActive = () => branches.every(Boolean);
+
+    for (const line of lines) {
+        const ifMatch = IF_DIRECTIVE.exec(line);
+        if (ifMatch) {
+            const negated = ifMatch[1] === "!";
+            const value = ifMatch[2];
+            const matches = negated ? targetBrowser !== value : targetBrowser === value;
+            branches.push(matches);
+            output.push("");
+            continue;
+        }
+
+        if (ENDIF_DIRECTIVE.test(line)) {
+            if (branches.length === 0) {
+                throw new Error("Unbalanced @endif in preprocessed source");
+            }
+            branches.pop();
+            output.push("");
+            continue;
+        }
+
+        output.push(isActive() ? line : "");
+    }
+
+    if (branches.length !== 0) {
+        throw new Error("Unclosed @if in preprocessed source");
+    }
+
+    return output.join("\n");
+}
+
+export { preprocessPreservingLines };

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadPage } from "./helpers/load-page.js";
+
+describe("options page", () => {
+    let optionsPage;
+    let browser;
+    let $;
+
+    beforeEach(async () => {
+        ({ page: optionsPage, browser, $ } = await loadPage({
+            script: "options.js",
+            page: "options.html",
+            dependencies: [{ script: "feedly.api.js", expose: ["FeedlyApiClient"] }],
+            expose: [
+                "getSyncArea",
+                "computeGlobalFavorites",
+                "computeGlobalUncategorized",
+                "parseFilters",
+                "saveOptions",
+                "loadOptions",
+                "setAllSitesPermission"
+            ]
+        }));
+    });
+
+    describe("getSyncArea", () => {
+        it("uses sync storage by default", () => {
+            expect(optionsPage.getSyncArea(false)).toBe(browser.storage.sync);
+        });
+
+        it("uses local storage when syncing is disabled", () => {
+            expect(optionsPage.getSyncArea(true)).toBe(browser.storage.local);
+        });
+    });
+
+    describe("stream id helpers", () => {
+        it("builds the favorites stream id", () => {
+            expect(optionsPage.computeGlobalFavorites("u1")).toBe("user/u1/category/global.must");
+        });
+
+        it("builds the uncategorized stream id", () => {
+            expect(optionsPage.computeGlobalUncategorized("u1")).toBe("user/u1/category/global.uncategorized");
+        });
+    });
+
+    describe("parseFilters", () => {
+        it("returns the ids of checked category boxes only", () => {
+            $("#categories").append(
+                $("<input type='checkbox' />").attr("data-id", "cat/A").prop("checked", true),
+                $("<input type='checkbox' />").attr("data-id", "cat/B"),
+                $("<input type='checkbox' />").attr("data-id", "cat/C").prop("checked", true)
+            );
+
+            expect(optionsPage.parseFilters()).toEqual(["cat/A", "cat/C"]);
+        });
+
+        it("returns an empty list when nothing is checked", () => {
+            expect(optionsPage.parseFilters()).toEqual([]);
+        });
+    });
+
+    describe("saveOptions", () => {
+        it("coerces each control to the type its option expects", async () => {
+            $("#updateInterval").val("25");
+            $("#maxNumberOfFeeds").val("50");
+            $("#markReadOnClick").prop("checked", true);
+            $("#showFullFeedContent").prop("checked", false);
+            $("#sortBy").val("oldest");
+
+            await optionsPage.saveOptions();
+
+            const stored = await browser.storage.sync.get(null);
+            expect(stored.updateInterval).toBe(25);
+            expect(stored.maxNumberOfFeeds).toBe(50);
+            expect(stored.markReadOnClick).toBe(true);
+            expect(stored.showFullFeedContent).toBe(false);
+            expect(stored.sortBy).toBe("oldest");
+        });
+
+        it("stores the selected category filters", async () => {
+            $("#categories").append(
+                $("<input type='checkbox' />").attr("data-id", "cat/A").prop("checked", true)
+            );
+
+            await optionsPage.saveOptions();
+
+            expect((await browser.storage.sync.get(null)).filters).toEqual(["cat/A"]);
+        });
+
+        it("writes to local storage when syncing is disabled", async () => {
+            $("#disableOptionsSync").prop("checked", true);
+
+            await optionsPage.saveOptions();
+
+            expect(await browser.storage.sync.get(null)).toEqual({});
+            expect((await browser.storage.local.get(null)).disableOptionsSync).toBe(true);
+        });
+    });
+
+    describe("setAllSitesPermission", () => {
+        it("does not ask for permission when neither option is enabled", async () => {
+            let requested = false;
+            browser.permissions.request = async () => {
+                requested = true;
+                return true;
+            };
+
+            await optionsPage.setAllSitesPermission(false, {});
+
+            expect(requested).toBe(false);
+        });
+
+        /*
+         * The <all_urls> grant is a browser-level prompt that Playwright cannot
+         * accept, so the denial path is covered here rather than in e2e.
+         */
+        it("unchecks both notification options when the grant is denied", async () => {
+            browser.permissions.request = async () => false;
+            $("#showBlogIconInNotifications").prop("checked", true);
+            $("#showThumbnailInNotifications").prop("checked", true);
+            const options = {
+                showBlogIconInNotifications: true,
+                showThumbnailInNotifications: true
+            };
+
+            await optionsPage.setAllSitesPermission(true, options);
+
+            expect(options.showBlogIconInNotifications).toBe(false);
+            expect(options.showThumbnailInNotifications).toBe(false);
+            expect($("#showBlogIconInNotifications").is(":checked")).toBe(false);
+            expect($("#showThumbnailInNotifications").is(":checked")).toBe(false);
+        });
+
+        it("keeps both options when the grant is allowed", async () => {
+            browser.permissions.request = async () => true;
+            $("#showBlogIconInNotifications").prop("checked", true);
+            $("#showThumbnailInNotifications").prop("checked", true);
+            const options = {
+                showBlogIconInNotifications: true,
+                showThumbnailInNotifications: true
+            };
+
+            await optionsPage.setAllSitesPermission(true, options);
+
+            expect(options.showBlogIconInNotifications).toBe(true);
+            expect(options.showThumbnailInNotifications).toBe(true);
+        });
+    });
+
+    describe("loadOptions", () => {
+        it("populates the form from storage", async () => {
+            await browser.storage.sync.set({
+                updateInterval: 30,
+                maxNumberOfFeeds: 75,
+                markReadOnClick: true,
+                sortBy: "oldest"
+            });
+
+            await optionsPage.loadOptions();
+
+            expect($("#updateInterval").val()).toBe("30");
+            expect($("#maxNumberOfFeeds").val()).toBe("75");
+            expect($("#sortBy").val()).toBe("oldest");
+        });
+
+        it("keeps the notification options off without the all-sites permission", async () => {
+            browser.permissions.contains = async () => false;
+            await browser.storage.sync.set({
+                showBlogIconInNotifications: true,
+                showThumbnailInNotifications: true
+            });
+
+            await optionsPage.loadOptions();
+
+            expect($("#showBlogIconInNotifications").is(":checked")).toBe(false);
+            expect($("#showThumbnailInNotifications").is(":checked")).toBe(false);
+        });
+    });
+});

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadPage } from "./helpers/load-page.js";
+
+const POPUP_EXPORTS = [
+    "getUniqueCategories",
+    "getSystemTheme",
+    "applyTheme",
+    "setTheme",
+    "executeAsync",
+    "options",
+    "environment",
+    "bg"
+];
+
+async function loadPopup(overrides = {}) {
+    return loadPage({
+        script: "popup.js",
+        page: "popup.html",
+        expose: POPUP_EXPORTS,
+        ...overrides
+    });
+}
+
+describe("popup page", () => {
+    describe("getUniqueCategories", () => {
+        let popup;
+
+        beforeEach(async () => {
+            ({ page: popup } = await loadPopup());
+        });
+
+        it("collects categories across feeds without repeating them", () => {
+            const feeds = [
+                { categories: [{ id: "cat/A", label: "A" }, { id: "cat/B", label: "B" }] },
+                { categories: [{ id: "cat/B", label: "B" }, { id: "cat/C", label: "C" }] }
+            ];
+
+            expect(popup.getUniqueCategories(feeds).map(category => category.id))
+                .toEqual(["cat/A", "cat/B", "cat/C"]);
+        });
+
+        it("preserves the order each category was first seen in", () => {
+            const feeds = [
+                { categories: [{ id: "cat/Z" }] },
+                { categories: [{ id: "cat/A" }] }
+            ];
+
+            expect(popup.getUniqueCategories(feeds).map(category => category.id))
+                .toEqual(["cat/Z", "cat/A"]);
+        });
+
+        it("returns nothing for an empty feed list", () => {
+            expect(popup.getUniqueCategories([])).toEqual([]);
+        });
+
+        it("returns nothing when no feed has categories", () => {
+            expect(popup.getUniqueCategories([{ categories: [] }])).toEqual([]);
+        });
+    });
+
+    describe("theme", () => {
+        it("reports the system theme as light by default", async () => {
+            const { page: popup } = await loadPopup({ prefersDark: false });
+
+            expect(popup.getSystemTheme()).toBe("light");
+        });
+
+        it("reports the system theme as dark when the media query matches", async () => {
+            const { page: popup } = await loadPopup({ prefersDark: true });
+
+            expect(popup.getSystemTheme()).toBe("dark");
+        });
+
+        it.each([
+            ["dark", "dark"],
+            ["nord", "nord"]
+        ])("marks the body with data-theme=%s", async (theme, expected) => {
+            const { page: popup } = await loadPopup();
+
+            popup.applyTheme(theme);
+
+            expect(document.body.getAttribute("data-theme")).toBe(expected);
+        });
+
+        it("removes the attribute for the light theme", async () => {
+            const { page: popup } = await loadPopup();
+            popup.applyTheme("dark");
+
+            popup.applyTheme("light");
+
+            expect(document.body.hasAttribute("data-theme")).toBe(false);
+        });
+
+        it("resolves the auto theme against a dark system preference", async () => {
+            const { page: popup } = await loadPopup({ prefersDark: true });
+            popup.options.theme = "auto";
+
+            popup.setTheme();
+
+            expect(document.body.getAttribute("data-theme")).toBe("dark");
+        });
+
+        it("resolves the auto theme against a light system preference", async () => {
+            const { page: popup } = await loadPopup({ prefersDark: false });
+            popup.options.theme = "auto";
+
+            popup.setTheme();
+
+            expect(document.body.hasAttribute("data-theme")).toBe(false);
+        });
+
+        it("follows later system changes while on the auto theme", async () => {
+            const { page: popup, themeListeners } = await loadPopup({ prefersDark: false });
+            popup.options.theme = "auto";
+            popup.setTheme();
+
+            themeListeners.forEach(listener => listener({ matches: true }));
+
+            expect(document.body.getAttribute("data-theme")).toBe("dark");
+        });
+
+        it("ignores system changes when a theme is pinned", async () => {
+            const { page: popup, themeListeners } = await loadPopup({ prefersDark: false });
+            popup.options.theme = "light";
+
+            popup.setTheme();
+
+            expect(themeListeners).toHaveLength(0);
+        });
+    });
+
+    describe("bg bridge", () => {
+        it("sends the message type alone when there is no payload", async () => {
+            const { page: popup, browser } = await loadPopup();
+
+            popup.bg.send("getState");
+
+            expect(browser._calls.messagesSent).toEqual([{ type: "getState" }]);
+        });
+
+        it("merges the payload into the message", async () => {
+            const { page: popup, browser } = await loadPopup();
+
+            popup.bg.send("getFeeds", { forceUpdate: true });
+
+            expect(browser._calls.messagesSent).toEqual([{ type: "getFeeds", forceUpdate: true }]);
+        });
+    });
+
+    describe("executeAsync", () => {
+        it("runs on the next tick away from macOS", async () => {
+            const { page: popup } = await loadPopup();
+            let ran = false;
+
+            popup.executeAsync(() => {
+                ran = true;
+            });
+
+            expect(ran).toBe(false);
+            await new Promise(resolve => setTimeout(resolve, 10));
+            expect(ran).toBe(true);
+        });
+
+        // The popup must yield before acting on macOS, or the window closes first.
+        it("defers on macOS", async () => {
+            const { page: popup } = await loadPopup();
+            popup.environment.os = "mac";
+            let ran = false;
+
+            popup.executeAsync(() => {
+                ran = true;
+            });
+
+            expect(ran).toBe(false);
+            await new Promise(resolve => setTimeout(resolve, 600));
+            expect(ran).toBe(true);
+        });
+    });
+});

--- a/test/preprocess.test.js
+++ b/test/preprocess.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { preprocess } from "preprocess";
+
+import { preprocessPreservingLines } from "./helpers/preprocess.js";
+import { projectRoot } from "./helpers/load-core.js";
+
+/**
+ * The unit suites evaluate a line-preserving preprocessing of src/, so that
+ * coverage and stack traces line up with the real files. These tests pin that
+ * implementation against the `preprocess` package the Grunt build actually
+ * uses, so the two can never silently diverge.
+ */
+const BROWSERS = ["chrome", "opera", "firefox"];
+
+const PREPROCESSED_FILES = [
+    "src/scripts/core.js",
+    "src/scripts/feedly.api.js",
+    "src/scripts/popup.js",
+    "src/manifest.json"
+];
+
+/** Both tools agree only up to the blank lines one of them leaves behind. */
+function significantLines(text) {
+    return text.split("\n").map(line => line.trimEnd()).filter(line => line !== "");
+}
+
+describe("line-preserving preprocessor", () => {
+    describe.each(BROWSERS)("for %s", (targetBrowser) => {
+        it.each(PREPROCESSED_FILES)("produces the same output as the build tool for %s", (relativePath) => {
+            const source = readFileSync(path.join(projectRoot, relativePath), "utf8");
+
+            const ours = preprocessPreservingLines(source, targetBrowser);
+            const theirs = preprocess(source, { BROWSER: targetBrowser }, { type: "js" });
+
+            expect(significantLines(ours)).toEqual(significantLines(theirs));
+        });
+    });
+
+    it("keeps the line count of the source", () => {
+        const source = readFileSync(path.join(projectRoot, "src/scripts/core.js"), "utf8");
+
+        const ours = preprocessPreservingLines(source, "chrome");
+
+        expect(ours.split("\n")).toHaveLength(source.split("\n").length);
+    });
+
+    it("keeps browser-specific statements on their original line numbers", () => {
+        const source = readFileSync(path.join(projectRoot, "src/scripts/feedly.api.js"), "utf8");
+        const originalLine = source.split("\n").findIndex(line => line.includes("browserPrefix = \"c\""));
+
+        const processed = preprocessPreservingLines(source, "chrome").split("\n");
+
+        expect(processed[originalLine]).toContain("browserPrefix = \"c\"");
+    });
+
+    it("resolves manifest.json into valid JSON", () => {
+        const source = readFileSync(path.join(projectRoot, "src/manifest.json"), "utf8");
+
+        // The raw file is not parseable: it carries // comments and directives.
+        expect(() => JSON.parse(source)).toThrow();
+
+        const chromeManifest = JSON.parse(stripComments(preprocessPreservingLines(source, "chrome")));
+        const firefoxManifest = JSON.parse(stripComments(preprocessPreservingLines(source, "firefox")));
+
+        expect(chromeManifest.manifest_version).toBe(3);
+        expect(chromeManifest.permissions).toContain("sidePanel");
+        expect(chromeManifest.side_panel).toBeDefined();
+
+        expect(firefoxManifest.permissions).not.toContain("sidePanel");
+        expect(firefoxManifest.sidebar_action).toBeDefined();
+        expect(firefoxManifest.applications.gecko.strict_min_version).toBe("115.0");
+    });
+
+    it("selects a different branch for each browser", () => {
+        const source = readFileSync(path.join(projectRoot, "src/scripts/feedly.api.js"), "utf8");
+
+        expect(preprocessPreservingLines(source, "chrome")).toContain("browserPrefix = \"c\"");
+        expect(preprocessPreservingLines(source, "chrome")).not.toContain("browserPrefix = \"f\"");
+        expect(preprocessPreservingLines(source, "opera")).toContain("browserPrefix = \"o\"");
+        expect(preprocessPreservingLines(source, "firefox")).toContain("browserPrefix = \"f\"");
+    });
+
+    it("rejects unbalanced directives", () => {
+        expect(() => preprocessPreservingLines("// @endif\n", "chrome")).toThrow(/Unbalanced/);
+        expect(() => preprocessPreservingLines("// @if BROWSER='chrome'\n", "chrome")).toThrow(/Unclosed/);
+    });
+});
+
+/** manifest.json keeps plain `//` comments outside the directives. */
+function stripComments(json) {
+    return json
+        .split("\n")
+        .map(line => (/^\s*\/\//.test(line) ? "" : line))
+        .join("\n");
+}

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        globals: true,
+        // Most suites evaluate the background scripts in a `vm` sandbox and need
+        // no DOM. The two page-script suites opt in with a
+        // `@vitest-environment jsdom` docblock.
+        environment: "node",
+        include: ["test/**/*.test.js"],
+        clearMocks: true,
+        restoreMocks: true,
+        coverage: {
+            provider: "v8",
+            include: ["src/scripts/**/*.js"],
+            /*
+             * popup.js and options.js are exercised by test/popup.test.js and
+             * test/options.test.js, but they are loaded with indirect eval into
+             * jsdom (they need a real DOM and the real jQuery). v8 cannot
+             * attribute eval'd code back to a source file, so leaving them in
+             * would report a misleading 0%. Their behaviour is covered by those
+             * two suites plus the Playwright specs in e2e/.
+             */
+            exclude: ["src/scripts/popup.js", "src/scripts/options.js"],
+            reporter: ["text", "lcov"],
+            reportsDirectory: "coverage"
+        }
+    }
+});


### PR DESCRIPTION
Adds the two test suites the repository has been missing. Until now the CI job named `test` only ran lint and a build, and `e2e/` was an empty directory. **No production source file is modified.**

- **Unit tests** — 220 tests across 11 files (Vitest), ~1.7s
- **End-to-end tests** — 39 tests across 5 specs (Playwright, Chromium), ~32s headless

## Why the harness looks the way it does

The five source files export nothing — they are classic browser globals joined at runtime by `importScripts`. Rather than change them, `test/helpers/load-core.js` evaluates them in a fresh `vm` context per test and hands back `appGlobal` and the top-level functions. A fresh context per test is also the only way to reset module-level state.

Two details drove the design:

- **`let` never reaches the context.** `feedly.api.js` declares `let FeedlyApiClient`, which does not become a property of the vm global. A second `vm.Script` in the *same* context does see it, so the files are run as separate scripts, each keeping its real filename — which means stack traces and coverage point at the actual `src/` lines.
- **The `// @if BROWSER='...'` directives are comments.** Raw `src/` therefore executes *every* branch and the last one wins — unpreprocessed, `getMethodUrl` always reports firefox. The loaders preprocess first, using a line-preserving implementation because the upstream `preprocess` package deletes lines and would shift coverage by ~20 lines. `test/preprocess.test.js` pins that implementation against the package the Grunt build actually uses, for all three browser targets.

For end-to-end, Playwright **cannot** intercept a service worker's own fetches, and the documented workaround (`serviceWorkers: 'block'`) would disable the extension outright. So the suite launches Chromium with `--host-resolver-rules` pointing `cloud.feedly.com` at a local mock server and rewrites the built API URL from https to http. The shipped `*://*.feedly.com/*` host permission already covers http, so **the manifest is exercised exactly as released** — no test-only manifest patching. Every other host resolves to nothing, so the suite is hermetic.

## Bugs the tests pin

These assert current behaviour rather than endorse it, and are marked `KNOWN BUG` / `KNOWN BEHAVIOUR` with a file and line reference:

- `core.js:940` — `markAsRead` coerces the badge text with `+`, so above 999 it reads `"1k+"` → `NaN` and the decrement is silently skipped.
- `core.js:514` — cached feeds are JSON-serialised into storage, so after a service-worker restart `date` is a string compared against a `Date`; new-feed notifications go silent.
- `core.js:589-617` — with filters enabled the summing loop sits after `await getUserSubscriptions()` inside the same `try`, so a failed subscription lookup clears the badge instead of falling back to the un-deduplicated total.

## Coverage

73.5% of statements on the background scripts (`core.js` 71%, `background.js` 92%, `feedly.api.js` 86%). `popup.js` and `options.js` are excluded from the report because they are loaded via indirect eval into jsdom and v8 cannot attribute eval'd code to a source file; their behaviour is covered by `test/popup.test.js`, `test/options.test.js` and the Playwright specs.

## CI

- `npm test` joins the existing lint + build job (cheap enough to run across the browser matrix).
- A **separate** `e2e` job runs the Chromium suite once, using dummy `clientId`/`clientSecret` rather than the repository secrets — the suite never exercises real OAuth, so this also works on pull requests from forks.
- **Node 20.x → 22.x**, required because Vitest 5 declares `node ^22.12 || ^24 || >=26`. Node 20 is end of life anyway.

## Verification

- `npm run lint` clean; `npm test` 220 passing; `npm run test:e2e` 39 passing, run twice with no flakes.
- **Mutation-checked**: breaking the title-truncation boundary and the `>999` badge threshold failed exactly the four covering tests, confirming the suite bites. Source restored afterwards.
- Confirmed the e2e https→http rewrite cannot leak into a release: a real `grunt build --browser=firefox` still ships https, no localhost, the correct `f` analytics prefix, and `sidebar_action` rather than `side_panel`. `grunt build` starts with `clean:pre-build`, so the unpacked e2e build is never reused.

## Note for the reviewer

The new `e2e` job creates a status check that is **not** required until it is added in repository settings. Since Dependabot auto-merge gates on the required checks, it is worth adding `e2e` there before relying on it.

## Follow-up commits

The first push failed the SonarCloud quality gate on `new_security_rating`. Addressed in the two follow-up commits, and the gate now passes with **0 open issues and A ratings across the board**:

- **Genuine fixes**: `npm ci --ignore-scripts` for a reproducible install that runs no dependency lifecycle scripts (verified locally that Vitest, Grunt and Playwright all work under it); the locally installed Playwright binary instead of `npx`; optional chaining, `Object.hasOwn`, object spread, class fields, `includes` over `indexOf`; and the directive regex rewritten so its optional trailing group cannot backtrack.
- **`expect.poll` → `expect(...).toPass()`** wherever a test's only assertion was hidden inside a helper or a poll. Static analysis flagged those as assertion-free tests, and it had a point — the assertions are now visible to readers too. Also dropped a `check({ force: true })`; the saved-feeds slider is actionable without it.
- **Five `NOSONAR` suppressions**, each with an inline reason: two for `new vm.Script(...)` in the unit loader (compiling this repo's own checked-in source is what the loader is for), and three for the deliberate `http://` in the e2e fixtures (the loopback mock answers plain HTTP so the suite needs no self-signed certificate). These are the only suppressions in the PR — worth a look if you disagree with either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive unit and browser-based coverage for feeds, badge counts, article actions, saved items, themes, options persistence, authentication recovery, and extension startup.
  - Added Chromium extension checks for signed-in, signed-out, empty, filtered, and error-recovery experiences, including popup console-error detection.
  - Added automated failure diagnostics and test reports for CI runs.

- **Documentation**
  - Expanded contributor guidance for running unit and end-to-end tests.

- **Chores**
  - Updated Node.js support, browser test workflows, linting, reporting, and test commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->