### PR TITLE
Stop exhausting the Feedly API quota

### DIFF
--- a/e2e/fixtures/feedly-server.js
+++ b/e2e/fixtures/feedly-server.js
@@ -37,8 +37,21 @@ class FeedlyMockServer {
     }
 
     /** Makes the next request to a matching path fail with `status`. */
-    failNext(pathFragment, status) {
-        this.failures.set(pathFragment, status);
+    failNext(pathFragment, status, headers) {
+        this.failures.set(pathFragment, { status, headers, remaining: 1 });
+    }
+
+    /** Makes the next `times` requests to a matching path fail with `status`. */
+    failTimes(pathFragment, status, times, headers) {
+        this.failures.set(pathFragment, { status, headers, remaining: times });
+    }
+
+    /**
+     * Makes every request to a matching path fail until `reset()`. Needed to model a
+     * quota that stays exhausted, or a refresh token feedly keeps rejecting.
+     */
+    failAlways(pathFragment, status, headers) {
+        this.failures.set(pathFragment, { status, headers, remaining: Infinity });
     }
 
     setStream(streamId, items) {
@@ -106,10 +119,14 @@ class FeedlyMockServer {
                 });
             }
 
-            for (const [fragment, status] of this.failures) {
+            for (const [fragment, failure] of this.failures) {
                 if (url.pathname.includes(fragment)) {
-                    this.failures.delete(fragment);
-                    return this.send(response, status, { errorMessage: "forced failure" });
+                    failure.remaining--;
+                    if (failure.remaining <= 0) {
+                        this.failures.delete(fragment);
+                    }
+                    return this.send(response, failure.status,
+                        { errorMessage: "forced failure" }, failure.headers || {});
                 }
             }
 

--- a/e2e/quota-protection.spec.js
+++ b/e2e/quota-protection.spec.js
@@ -1,0 +1,117 @@
+const { test, expect, RETRY } = require("./fixtures/extension");
+const { SUBSCRIPTIONS, GLOBAL_ALL } = require("./fixtures/feed-items");
+
+/**
+ * Regression cover for issue #368, where the extension exhausted the account's feedly
+ * api quota and feedly started answering 429 (HAP429) for the website too.
+ *
+ * Both scenarios drive the update cycle explicitly rather than waiting for the alarm:
+ * the update interval has a ten minute floor, so an alarm would never fire inside a
+ * test. `updateCounter` and `updateFeeds` are top level declarations in the worker, so
+ * they are reachable on its global.
+ */
+test.describe("api quota protection", () => {
+    test.beforeEach(async ({ mockApi }) => {
+        mockApi.subscriptions = SUBSCRIPTIONS;
+        mockApi.setStream(GLOBAL_ALL, []);
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 7 });
+    });
+
+    function runUpdateCycle(serviceWorker) {
+        return serviceWorker.evaluate(async () => {
+            await globalThis.updateCounter();
+            await globalThis.updateFeeds();
+        });
+    }
+
+    test("stops calling the api once feedly reports the quota is spent", async ({ mockApi, signIn, serviceWorker }) => {
+        await signIn();
+
+        // Let the sign-in poll finish, so its requests are not counted as the cooldown's.
+        await expect(async () => {
+            expect(mockApi.requestsFor("/v3/markers/counts").length).toBeGreaterThan(0);
+        }).toPass(RETRY);
+
+        mockApi.failAlways("markers/counts", 429, { "Retry-After": "600" });
+        await runUpdateCycle(serviceWorker);
+
+        await expect(async () => {
+            expect(await serviceWorker.evaluate(() => globalThis.appGlobal.rateLimitedUntil))
+                .toBeGreaterThan(Date.now());
+        }).toPass(RETRY);
+
+        const afterCooldown = mockApi.requests.length;
+
+        await runUpdateCycle(serviceWorker);
+        await runUpdateCycle(serviceWorker);
+        await runUpdateCycle(serviceWorker);
+
+        expect(mockApi.requests.length).toBe(afterCooldown);
+    });
+
+    test("keeps the last known badge count through a rate limit", async ({ mockApi, signIn, serviceWorker }) => {
+        await signIn();
+
+        await expect(async () => {
+            expect(await serviceWorker.evaluate(() => chrome.action.getBadgeText({}))).toBe("7");
+        }).toPass(RETRY);
+
+        mockApi.failAlways("markers/counts", 429, { "Retry-After": "600" });
+        await runUpdateCycle(serviceWorker);
+
+        expect(await serviceWorker.evaluate(() => chrome.action.getBadgeText({}))).toBe("7");
+    });
+
+    /*
+     * The headline regression. A refresh token feedly has permanently rejected used to
+     * leave the extension retrying on every alarm forever, which is what spent the quota.
+     * Users escaped it by deleting the tokens by hand; the extension now does it itself.
+     */
+    test("signs out when feedly permanently rejects the refresh token", async ({ mockApi, signIn, serviceWorker }) => {
+        await signIn();
+
+        mockApi.failAlways("markers/counts", 401);
+        mockApi.failAlways("streams", 401);
+        mockApi.failAlways("auth/token", 400);
+
+        await runUpdateCycle(serviceWorker);
+
+        await expect(async () => {
+            const stored = await serviceWorker.evaluate(() => chrome.storage.sync.get(["accessToken", "refreshToken"]));
+            expect(stored).toMatchObject({ accessToken: "", refreshToken: "" });
+        }).toPass(RETRY);
+
+        // The schedule has to be gone too, otherwise the alarms keep spending requests.
+        await expect(async () => {
+            const alarms = await serviceWorker.evaluate(() => chrome.alarms.getAll());
+            expect(alarms.map(alarm => alarm.name)).not.toContain("updateCounter");
+            expect(alarms.map(alarm => alarm.name)).not.toContain("updateFeeds");
+        }).toPass(RETRY);
+
+        const afterSignOut = mockApi.requests.length;
+        await runUpdateCycle(serviceWorker);
+
+        expect(mockApi.requests.length).toBe(afterSignOut);
+    });
+
+    /*
+     * updateFeeds asks for one stream per filtered category in parallel, so an expired
+     * token fails all of them at once. Each failure used to ask for its own new token.
+     */
+    test("asks for a new token only once when a whole cycle expires together", async ({ mockApi, signIn, serviceWorker }) => {
+        await signIn({ filters: ["cat-a", "cat-b", "cat-c"], isFiltersEnabled: true });
+
+        await expect(async () => {
+            expect(mockApi.requestsFor("/v3/streams").length).toBeGreaterThanOrEqual(3);
+        }).toPass(RETRY);
+
+        mockApi.failTimes("streams", 401, 3);
+
+        const before = mockApi.requestsTo("/v3/auth/token", "POST").length;
+        await serviceWorker.evaluate(() => globalThis.updateFeeds());
+
+        expect(mockApi.requestsTo("/v3/auth/token", "POST").length - before).toBe(1);
+        // All three retried and succeeded, so the cycle still did its job.
+        expect(mockApi.requestsFor("/v3/streams").length).toBeGreaterThanOrEqual(9);
+    });
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -75,7 +75,7 @@
     ],
 
     // @if BROWSER!='firefox'
-    "minimum_chrome_version": "88",
+    "minimum_chrome_version": "114",
     // @endif
     // @if BROWSER='firefox'
     "applications": {

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -910,6 +910,7 @@ async function clearStoredTokens() {
     // label their articles with the previous account's subscription titles.
     appGlobal.getUserSubscriptionsPromise = null;
     setInactiveStatus();
+    await clearRateLimitCooldown();
 
     try {
         // The area the options are read from goes first, otherwise the storage event for
@@ -1240,6 +1241,9 @@ async function getAccessToken() {
         feedlyUserId: response.id
     });
 
+    // A cooldown left over from the previous credentials is not this account's
+    await clearRateLimitCooldown();
+
     setActiveStatus();
 }
 
@@ -1314,6 +1318,14 @@ async function requestNewAccessToken(){
    only prolongs the ban. */
 function isRateLimited() {
     return appGlobal.rateLimitedUntil > Date.now();
+}
+
+/* The quota belongs to the account, so a deadline recorded for one set of credentials
+   must not hold back the next. If feedly is still refusing, the next request records the
+   cooldown again at the cost of a single call. */
+async function clearRateLimitCooldown() {
+    appGlobal.rateLimitedUntil = 0;
+    await browser.storage.local.remove("rateLimitedUntil").catch(function () {});
 }
 
 async function startRateLimitCooldown(response) {
@@ -1420,47 +1432,45 @@ async function apiRequestWrapper(methodName, settings) {
     }
 
     try {
-        const response = await appGlobal.feedlyApiClient.request(methodName, settings);
-        setActiveStatus();
-        return response;
-    } catch (response) {
-        // Ahead of the 401 branch, so a 429 can never be mistaken for an expired token
-        if (response?.status === 429) {
-            await startRateLimitCooldown(response);
-            throw response;
-        }
-
-        if (response?.status !== 401) {
-            throw response;
+        return await sendRequest(methodName, settings);
+    } catch (error) {
+        // A 429 was already recorded by sendRequest, and must never be taken for an
+        // expired token, so only a 401 gets a new one.
+        if (error?.status !== 401) {
+            throw error;
         }
 
         await refreshAccessToken();
 
-        return await retryAfterRefresh(methodName, settings);
+        // Deliberately not back through the wrapper, so a retry cannot loop
+        return await sendRequest(methodName, settings);
     }
 }
 
 /*
- * The retry deliberately bypasses the wrapper, so it cannot loop, but it still needs the
- * cooldown: a token can expire while the account is already close to its quota, which
- * would otherwise leave the 429 unnoticed.
+ * Feedly rejects with the raw response, so a failure carries a status rather than being an
+ * Error. Both the first attempt and the retry after a refresh come through here, so a
+ * token that expires while the account is already close to its quota still records the
+ * cooldown instead of slipping past it.
  */
-async function retryAfterRefresh(methodName, settings) {
+async function sendRequest(methodName, settings) {
     try {
-        return await appGlobal.feedlyApiClient.request(methodName, settings);
-    } catch (response) {
-        if (response?.status === 429) {
-            await startRateLimitCooldown(response);
+        const response = await appGlobal.feedlyApiClient.request(methodName, settings);
+        setActiveStatus();
+        return response;
+    } catch (error) {
+        if (error?.status === 429) {
+            await startRateLimitCooldown(error);
         }
 
-        throw response;
+        throw error;
     }
 }
 
 /* Carries the status, so callers branch on it the way they do for a real api response. */
 function createRateLimitError() {
-    const error = new Error("Rate limited by feedly");
-    error.status = 429;
+    const rateLimitError = new Error("Rate limited by feedly");
+    rateLimitError.status = 429;
 
-    return error;
+    return rateLimitError;
 }

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -114,6 +114,15 @@ var appGlobal = {
     clientId: "",
     clientSecret: "",
     getUserSubscriptionsPromise: null,
+    refreshAccessTokenPromise: null,
+    websiteUpdateTimeoutId: null,
+    lastWebsiteUpdateTime: 0,
+    rateLimitedUntil: 0,
+    /* The statuses the token endpoint uses to say that the grant will never be accepted
+       again: 400 invalid_grant for an expired or revoked refresh token, 401 and 403 for
+       one that no longer belongs to this client. Anything else, 429 and 5xx included, is
+       temporary and must not sign the user out. */
+    deadRefreshTokenStatuses: [400, 401, 403],
     environment: {
         os: ""
     },
@@ -143,6 +152,17 @@ var appGlobal = {
     }
 };
 
+/* The feedly website marks entries as read one request at a time, so without a window
+   here reading a page of articles costs a full update per article. Kept below the
+   ~30 seconds a service worker stays alive after an event, so the trailing run fires. */
+const websiteUpdateWindowMs = 20000;
+
+/* How long to stop talking to feedly after it answers 429. The response usually says
+   when the quota resets, the rest is a guard against a missing or absurd value. */
+const rateLimitDefaultCooldownMs = 15 * 60 * 1000;
+const rateLimitMinCooldownMs = 60 * 1000;
+const rateLimitMaxCooldownMs = 60 * 60 * 1000;
+
 // #Event handlers
 browser.runtime.onInstalled.addListener(async function () {
     await readOptions();
@@ -156,21 +176,72 @@ browser.runtime.onStartup.addListener(async function () {
     await initialize();
 });
 
-browser.storage.onChanged.addListener(async function (changes, areaName) {
-    let shouldReinitialize = false;
+browser.storage.onChanged.addListener(async function (changes) {
+    // The feed caches, the notification watermark and the rate limit deadline share these
+    // storage areas and are written by this worker on every update cycle. Re-reading the
+    // options for them is pure noise.
+    if (!containsOptionChanges(changes)) {
+        return;
+    }
 
-    for (let optionName in changes) {
-        if (appGlobal.criticalOptionNames.indexOf(optionName) !== -1) {
-            shouldReinitialize = true;
-            break;
+    let previousToken = appGlobal.options.accessToken;
+    let snapshot = snapshotCriticalOptions();
+
+    await readOptions();
+
+    let changedOptions = getChangedCriticalOptions(snapshot);
+
+    // A write raises the event even when the value did not change, and writeOptions
+    // rewrites every option at once. Comparing the resolved options rather than the
+    // reported change also keeps signing out correct, where the two storage areas are
+    // written one after the other.
+    if (changedOptions.length === 0) {
+        return;
+    }
+
+    // A refreshed access token replaces one working token with another, and the request
+    // that asked for the refresh is already retrying with it. Reinitializing here would
+    // rebuild the schedule and start another update for every single refresh.
+    if (changedOptions.length === 1 && changedOptions[0] === "accessToken"
+        && previousToken && appGlobal.options.accessToken) {
+        appGlobal.feedlyApiClient.accessToken = appGlobal.options.accessToken;
+        return;
+    }
+
+    await initialize();
+});
+
+function containsOptionChanges(changes) {
+    for (let key in changes) {
+        if (Object.prototype.hasOwnProperty.call(appGlobal.options, key)) {
+            return true;
         }
     }
 
-    await readOptions();
-    if (shouldReinitialize) {
-        await initialize();
+    return false;
+}
+
+/* Values are stringified so that an array option such as the filters compares by content
+   rather than by identity. */
+function snapshotCriticalOptions() {
+    let snapshot = {};
+    for (let optionName of appGlobal.criticalOptionNames) {
+        snapshot[optionName] = JSON.stringify(appGlobal.options[optionName]);
     }
-});
+
+    return snapshot;
+}
+
+function getChangedCriticalOptions(snapshot) {
+    let changed = [];
+    for (let optionName of appGlobal.criticalOptionNames) {
+        if (snapshot[optionName] !== JSON.stringify(appGlobal.options[optionName])) {
+            changed.push(optionName);
+        }
+    }
+
+    return changed;
+}
 
 browser.tabs.onRemoved.addListener(function(tabId){
     if (appGlobal.feedTabId && appGlobal.feedTabId === tabId) {
@@ -180,22 +251,87 @@ browser.tabs.onRemoved.addListener(function(tabId){
 });
 
 /* Listener for adding or removing feeds on the feedly website */
-browser.webRequest.onCompleted.addListener(async function (details) {
-    if (details.method === "POST" || details.method === "DELETE") {
-        await ensureOptionsLoaded();
-        updateCounter();
-        updateFeeds();
+browser.webRequest.onCompleted.addListener(function (details) {
+    if (details.method !== "POST" && details.method !== "DELETE") {
+        return;
+    }
+
+    // Our own markers request already updated the cache and the badge, updating again
+    // would only repeat the work and the request.
+    if (isOwnRequest(details)) {
+        return;
+    }
+
+    // Only a subscriptions change can invalidate the memo, marking as read cannot.
+    if (details.url && details.url.indexOf("/v3/subscriptions") !== -1) {
         appGlobal.getUserSubscriptionsPromise = null;
     }
+
+    scheduleWebsiteUpdate();
 }, {urls: ["*://*.feedly.com/v3/subscriptions*", "*://*.feedly.com/v3/markers*"]});
 
 /* Listener for adding or removing saved feeds */
 browser.webRequest.onCompleted.addListener(async function (details) {
-    if (details.method === "PUT" || details.method === "DELETE") {
-        await ensureOptionsLoaded();
-        updateSavedFeeds();
+    if (details.method !== "PUT" && details.method !== "DELETE") {
+        return;
     }
+
+    if (isOwnRequest(details)) {
+        return;
+    }
+
+    await ensureOptionsLoaded();
+    updateSavedFeeds().catch(function (e) {
+        console.info("Unable to update saved feeds.", e);
+    });
 }, {urls: ["*://*.feedly.com/v3/tags*global.saved*"]});
+
+/* True when the extension itself made the request rather than the feedly website.
+   Chromium reports the origin in initiator, firefox in originUrl. The tab id is not
+   usable here, the feedly website is a progressive web app and its own service worker
+   makes requests without a tab too. */
+function isOwnRequest(details) {
+    // getURL ends in a slash, chrome reports initiator as a bare origin without one
+    let extensionOrigin = browser.runtime.getURL("").replace(/\/+$/, "");
+    let initiator = details.initiator || details.originUrl || "";
+
+    return initiator.length > 0 && initiator.indexOf(extensionOrigin) === 0;
+}
+
+/* Coalesces a burst of website activity into a single update. Runs straight away when
+   the window is clear, otherwise collects everything into one trailing run. */
+function scheduleWebsiteUpdate() {
+    let elapsed = Date.now() - appGlobal.lastWebsiteUpdateTime;
+
+    if (elapsed >= websiteUpdateWindowMs) {
+        runWebsiteUpdateSafely();
+        return;
+    }
+
+    if (appGlobal.websiteUpdateTimeoutId === null) {
+        appGlobal.websiteUpdateTimeoutId = setTimeout(runWebsiteUpdateSafely, websiteUpdateWindowMs - elapsed);
+    }
+}
+
+/* Nothing awaits these runs, so a failure here would surface as an unhandled rejection. */
+function runWebsiteUpdateSafely() {
+    runWebsiteUpdate().catch(function (e) {
+        console.info("Unable to update after a change on the feedly website.", e);
+    });
+}
+
+async function runWebsiteUpdate() {
+    if (appGlobal.websiteUpdateTimeoutId !== null) {
+        clearTimeout(appGlobal.websiteUpdateTimeoutId);
+        appGlobal.websiteUpdateTimeoutId = null;
+    }
+
+    appGlobal.lastWebsiteUpdateTime = Date.now();
+
+    await ensureOptionsLoaded();
+    updateCounter();
+    updateFeeds();
+}
 
 browser.action.onClicked.addListener(function (tab) {
     //The side panel may only be opened from within the user gesture, which any
@@ -309,6 +445,13 @@ function startSchedule(updateInterval, immediate) {
     // When shouldRecreate is false (worker wake), keep existing alarms as-is and avoid immediate fetch.
     if (shouldRecreate) {
         stopSchedule();
+
+        // Without a token every scheduled request fails, and every failure wakes the
+        // worker again. Stay quiet until the user signs in.
+        if (!appGlobal.options.accessToken) {
+            return;
+        }
+
         if (appGlobal.options.showCounter) {
             browser.alarms.create("updateCounter", { periodInMinutes: updateInterval });
         }
@@ -533,6 +676,10 @@ async function resetCounter(){
  * @returns {Promise}
  */
 async function updateSavedFeeds() {
+    if (isRateLimited()) {
+        return;
+    }
+
     const response = await apiRequestWrapper("streams/" + encodeURIComponent(appGlobal.savedGroup) + "/contents");
     const feeds = await parseFeeds(response);
     appGlobal.cachedSavedFeeds = feeds;
@@ -563,6 +710,10 @@ function setBadgeCounter(unreadFeedsCount) {
  * Callback will be started after function complete
  * */
 async function updateCounter() {
+    if (isRateLimited()) {
+        return;
+    }
+
     try {
         if (appGlobal.options.resetCounterOnClick) {
             const options = await browser.storage.local.get("lastCounterResetTime");
@@ -576,7 +727,11 @@ async function updateCounter() {
             await makeMarkersRequest();
         }
     } catch (e) {
-        await browser.action.setBadgeText({ text: ""});
+        // A rate limited cycle knows nothing about the count, so blanking the badge would
+        // throw the last good value away for the whole cooldown.
+        if (!e || e.status !== 429) {
+            await browser.action.setBadgeText({ text: ""});
+        }
         console.info("Unable to load counters.", e);
     }
 }
@@ -632,6 +787,10 @@ async function makeMarkersRequest(parameters){
  * If silentUpdate is true, then notifications will not be shown
  *  */
 async function updateFeeds(silentUpdate) {
+    if (isRateLimited()) {
+        return;
+    }
+
     const previousCache = appGlobal.cachedFeeds.slice(0);
     appGlobal.options.filters = appGlobal.options.filters || [];
 
@@ -722,6 +881,26 @@ function setInactiveStatus() {
     appGlobal.cachedFeeds = [];
     appGlobal.isLoggedIn = false;
     stopSchedule();
+}
+
+/* Drops credentials that feedly has permanently rejected and stops polling. Left in
+   storage a dead token keeps the scheduler awake, and every cycle spends requests that can
+   only fail, which is what exhausts the account's quota. Mirrors the options page logout,
+   which is the recovery users have been performing by hand. */
+async function clearStoredTokens() {
+    appGlobal.options.accessToken = "";
+    appGlobal.options.refreshToken = "";
+    appGlobal.feedlyApiClient.accessToken = "";
+    setInactiveStatus();
+
+    try {
+        // The area the options are read from goes first, otherwise the storage event for
+        // the other one would read the token back out of it and revive the session.
+        await appGlobal.syncStorage.set({ accessToken: "", refreshToken: "" });
+        await browser.storage.local.set({ accessToken: "", refreshToken: "" });
+    } catch (e) {
+        console.info("Unable to clear the stored tokens.", e);
+    }
 }
 
 /* Sets badge as active */
@@ -1048,8 +1227,22 @@ async function getAccessToken() {
 
 /**
  * Refreshes the access token.
+ *
+ * A whole update cycle can fail with 401 at once, so the grant is shared: the first caller
+ * performs it and the rest wait on the same promise. Without that, one expired token turns
+ * into one auth/token request per in-flight call.
  */
-async function refreshAccessToken(){
+function refreshAccessToken() {
+    if (!appGlobal.refreshAccessTokenPromise) {
+        appGlobal.refreshAccessTokenPromise = requestNewAccessToken().finally(function () {
+            appGlobal.refreshAccessTokenPromise = null;
+        });
+    }
+
+    return appGlobal.refreshAccessTokenPromise;
+}
+
+async function requestNewAccessToken(){
     if(!appGlobal.options.refreshToken) {
         setInactiveStatus();
         throw new Error("No refresh token available");
@@ -1067,14 +1260,20 @@ async function refreshAccessToken(){
             }
         });
 
+        // A grant that answers 200 without a token must not be stored, writing undefined
+        // over the token would make the failure permanent.
+        if (!response || !response.access_token) {
+            throw new Error("The refresh response contained no access token");
+        }
+
         // Update runtime variables immediately to prevent race conditions
         appGlobal.options.accessToken = response.access_token;
         appGlobal.options.feedlyUserId = response.id;
         appGlobal.feedlyApiClient.accessToken = response.access_token;
         appGlobal.isLoggedIn = true;
 
-        // Also save to storage for persistence
-        appGlobal.syncStorage.set({
+        // Awaited, so the retry cannot run before the new token is persisted
+        await appGlobal.syncStorage.set({
             accessToken: response.access_token,
             feedlyUserId: response.id
         });
@@ -1082,12 +1281,56 @@ async function refreshAccessToken(){
         setActiveStatus();
         return response;
     } catch (response) {
-        // If the refresh token is invalid
-        if (response && response.status === 403) {
-            setInactiveStatus();
+        if (response && response.status === 429) {
+            await startRateLimitCooldown(response);
+        } else if (response && appGlobal.deadRefreshTokenStatuses.indexOf(response.status) !== -1) {
+            console.info("The refresh token was rejected, signing out.", response.status);
+            await clearStoredTokens();
         }
         throw response;
     }
+}
+
+/* Feedly answers 429 (HAP429) once the account has spent its API quota, and it counts
+   against the whole account, so the feedly website starts failing too. Polling through it
+   only prolongs the ban. */
+function isRateLimited() {
+    return appGlobal.rateLimitedUntil > Date.now();
+}
+
+async function startRateLimitCooldown(response) {
+    const cooldown = parseRateLimitCooldown(response);
+    appGlobal.rateLimitedUntil = Date.now() + cooldown;
+
+    console.info("Feedly rate limited the account, pausing requests for "
+        + Math.round(cooldown / 60000) + " minutes.");
+
+    await browser.storage.local.set({ rateLimitedUntil: appGlobal.rateLimitedUntil })
+        .catch(function () {});
+}
+
+/* Feedly reports the seconds left in the current window in X-RateLimit-Reset, Retry-After
+   is the standard fallback and may hold either seconds or a date. The bounds guard against
+   a missing header on one side and a value that would mute the extension on the other. */
+function parseRateLimitCooldown(response) {
+    let cooldown = NaN;
+    const headers = response && response.headers;
+
+    if (headers && typeof headers.get === "function") {
+        const reset = headers.get("X-RateLimit-Reset") || headers.get("Retry-After");
+        if (reset) {
+            cooldown = Number(reset) * 1000;
+            if (isNaN(cooldown)) {
+                cooldown = Date.parse(reset) - Date.now();
+            }
+        }
+    }
+
+    if (isNaN(cooldown) || cooldown <= 0) {
+        cooldown = rateLimitDefaultCooldownMs;
+    }
+
+    return Math.min(Math.max(cooldown, rateLimitMinCooldownMs), rateLimitMaxCooldownMs);
 }
 
 /* Writes all application options in chrome storage and runs callback after it */
@@ -1128,9 +1371,12 @@ async function readOptions() {
     appGlobal.options.currentUiLanguage = browser.i18n.getUILanguage();
 
     // Preload cached feeds from local storage to serve immediately on popup open
-    const cache = await browser.storage.local.get(["cachedFeeds", "cachedSavedFeeds"]).catch(function () { return {}; });
+    const cache = await browser.storage.local.get(["cachedFeeds", "cachedSavedFeeds", "rateLimitedUntil"]).catch(function () { return {}; });
     appGlobal.cachedFeeds = Array.isArray(cache.cachedFeeds) ? cache.cachedFeeds : [];
     appGlobal.cachedSavedFeeds = Array.isArray(cache.cachedSavedFeeds) ? cache.cachedSavedFeeds : [];
+
+    // The alarm wakes a fresh worker, so the cooldown has to come back from storage
+    appGlobal.rateLimitedUntil = Number(cache.rateLimitedUntil) || 0;
 
     // If we have a token, treat as logged in until a request proves otherwise
     appGlobal.isLoggedIn = Boolean(appGlobal.options.accessToken);
@@ -1142,6 +1388,10 @@ async function apiRequestWrapper(methodName, settings) {
         return Promise.reject(new Error("No access token available"));
     }
 
+    if (isRateLimited()) {
+        return Promise.reject({ status: 429, message: "Rate limited by feedly" });
+    }
+
     settings = settings || {};
 
     try {
@@ -1149,6 +1399,12 @@ async function apiRequestWrapper(methodName, settings) {
         setActiveStatus();
         return response;
     } catch (response) {
+        // Ahead of the 401 branch, so a 429 can never be mistaken for an expired token
+        if (response && response.status === 429) {
+            await startRateLimitCooldown(response);
+            return Promise.reject(response);
+        }
+
         if (response && response.status === 401) {
             await refreshAccessToken();
             return await appGlobal.feedlyApiClient.request(methodName, settings);

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -214,8 +214,7 @@ browser.storage.onChanged.addListener(async function (changes) {
 
 function containsOptionChanges(changes) {
     for (let key in changes) {
-        // Not Object.hasOwn, which needs Chrome 93 and the manifest declares 88
-        if (Object.prototype.hasOwnProperty.call(appGlobal.options, key)) {
+        if (Object.hasOwn(appGlobal.options, key)) {
             return true;
         }
     }
@@ -1407,11 +1406,18 @@ async function apiRequestWrapper(methodName, settings) {
         throw new Error("No access token available");
     }
 
-    if (isRateLimited()) {
+    settings = settings || {};
+
+    /*
+     * Only reads are held back. They are the polling traffic that spends the quota, and
+     * updateCounter, updateFeeds and updateSavedFeeds all stop before reaching this. A
+     * write is something the user just asked for, so refusing it without trying would
+     * make the extension look broken for the whole cooldown -- and if feedly really is
+     * still refusing, the 429 that comes back refreshes the deadline anyway.
+     */
+    if ((!settings.method || settings.method === "GET") && isRateLimited()) {
         throw createRateLimitError();
     }
-
-    settings = settings || {};
 
     try {
         const response = await appGlobal.feedlyApiClient.request(methodName, settings);

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -104,7 +104,10 @@ var appGlobal = {
         "showCounter",
         "resetCounterOnClick",
         "grayIconColorIfNoUnread",
-        "sortBy"
+        "sortBy",
+        // Both decide whether startSchedule creates the updateFeeds alarm
+        "showDesktopNotifications",
+        "playSound"
     ],
     cachedFeeds: [],
     cachedSavedFeeds: [],
@@ -115,8 +118,6 @@ var appGlobal = {
     clientSecret: "",
     getUserSubscriptionsPromise: null,
     refreshAccessTokenPromise: null,
-    websiteUpdateTimeoutId: null,
-    lastWebsiteUpdateTime: 0,
     rateLimitedUntil: 0,
     /* The statuses the token endpoint uses to say that the grant will never be accepted
        again: 400 invalid_grant for an expired or revoked refresh token, 401 and 403 for
@@ -213,6 +214,7 @@ browser.storage.onChanged.addListener(async function (changes) {
 
 function containsOptionChanges(changes) {
     for (let key in changes) {
+        // Not Object.hasOwn, which needs Chrome 93 and the manifest declares 88
         if (Object.prototype.hasOwnProperty.call(appGlobal.options, key)) {
             return true;
         }
@@ -263,7 +265,7 @@ browser.webRequest.onCompleted.addListener(function (details) {
     }
 
     // Only a subscriptions change can invalidate the memo, marking as read cannot.
-    if (details.url && details.url.indexOf("/v3/subscriptions") !== -1) {
+    if (details.url && details.url.includes("/v3/subscriptions")) {
         appGlobal.getUserSubscriptionsPromise = null;
     }
 
@@ -271,7 +273,7 @@ browser.webRequest.onCompleted.addListener(function (details) {
 }, {urls: ["*://*.feedly.com/v3/subscriptions*", "*://*.feedly.com/v3/markers*"]});
 
 /* Listener for adding or removing saved feeds */
-browser.webRequest.onCompleted.addListener(async function (details) {
+browser.webRequest.onCompleted.addListener(function (details) {
     if (details.method !== "PUT" && details.method !== "DELETE") {
         return;
     }
@@ -280,10 +282,7 @@ browser.webRequest.onCompleted.addListener(async function (details) {
         return;
     }
 
-    await ensureOptionsLoaded();
-    updateSavedFeeds().catch(function (e) {
-        console.info("Unable to update saved feeds.", e);
-    });
+    scheduleSavedFeedsUpdate();
 }, {urls: ["*://*.feedly.com/v3/tags*global.saved*"]});
 
 /* True when the extension itself made the request rather than the feedly website.
@@ -291,47 +290,64 @@ browser.webRequest.onCompleted.addListener(async function (details) {
    usable here, the feedly website is a progressive web app and its own service worker
    makes requests without a tab too. */
 function isOwnRequest(details) {
-    // getURL ends in a slash, chrome reports initiator as a bare origin without one
-    let extensionOrigin = browser.runtime.getURL("").replace(/\/+$/, "");
+    // getURL ends in exactly one slash, chrome reports initiator as a bare origin
+    let extensionOrigin = browser.runtime.getURL("").replace(/\/$/, "");
     let initiator = details.initiator || details.originUrl || "";
 
     return initiator.length > 0 && initiator.indexOf(extensionOrigin) === 0;
 }
 
-/* Coalesces a burst of website activity into a single update. Runs straight away when
-   the window is clear, otherwise collects everything into one trailing run. */
-function scheduleWebsiteUpdate() {
-    let elapsed = Date.now() - appGlobal.lastWebsiteUpdateTime;
+/**
+ * Wraps an update so that a burst of website activity costs one run instead of one per
+ * event: the first event runs straight away, everything else inside the window collapses
+ * into a single trailing run. Each throttle keeps its own timer, so saving an article
+ * cannot postpone the counter refresh or the other way round.
+ */
+function createWebsiteUpdateThrottle(runUpdate) {
+    let timeoutId = null;
+    let lastRunTime = 0;
 
-    if (elapsed >= websiteUpdateWindowMs) {
-        runWebsiteUpdateSafely();
-        return;
+    function runNow() {
+        if (timeoutId !== null) {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+        }
+
+        lastRunTime = Date.now();
+
+        // Nothing awaits this, so a failure would surface as an unhandled rejection
+        runUpdate().catch(function (e) {
+            console.info("Unable to update after a change on the feedly website.", e);
+        });
     }
 
-    if (appGlobal.websiteUpdateTimeoutId === null) {
-        appGlobal.websiteUpdateTimeoutId = setTimeout(runWebsiteUpdateSafely, websiteUpdateWindowMs - elapsed);
-    }
-}
+    return function () {
+        let elapsed = Date.now() - lastRunTime;
 
-/* Nothing awaits these runs, so a failure here would surface as an unhandled rejection. */
-function runWebsiteUpdateSafely() {
-    runWebsiteUpdate().catch(function (e) {
-        console.info("Unable to update after a change on the feedly website.", e);
-    });
+        if (elapsed >= websiteUpdateWindowMs) {
+            runNow();
+            return;
+        }
+
+        if (timeoutId === null) {
+            timeoutId = setTimeout(runNow, websiteUpdateWindowMs - elapsed);
+        }
+    };
 }
 
 async function runWebsiteUpdate() {
-    if (appGlobal.websiteUpdateTimeoutId !== null) {
-        clearTimeout(appGlobal.websiteUpdateTimeoutId);
-        appGlobal.websiteUpdateTimeoutId = null;
-    }
-
-    appGlobal.lastWebsiteUpdateTime = Date.now();
-
     await ensureOptionsLoaded();
     updateCounter();
     updateFeeds();
 }
+
+async function runSavedFeedsUpdate() {
+    await ensureOptionsLoaded();
+    await updateSavedFeeds();
+}
+
+const scheduleWebsiteUpdate = createWebsiteUpdateThrottle(runWebsiteUpdate);
+const scheduleSavedFeedsUpdate = createWebsiteUpdateThrottle(runSavedFeedsUpdate);
 
 browser.action.onClicked.addListener(function (tab) {
     //The side panel may only be opened from within the user gesture, which any
@@ -729,7 +745,7 @@ async function updateCounter() {
     } catch (e) {
         // A rate limited cycle knows nothing about the count, so blanking the badge would
         // throw the last good value away for the whole cooldown.
-        if (!e || e.status !== 429) {
+        if (e?.status !== 429) {
             await browser.action.setBadgeText({ text: ""});
         }
         console.info("Unable to load counters.", e);
@@ -891,6 +907,9 @@ async function clearStoredTokens() {
     appGlobal.options.accessToken = "";
     appGlobal.options.refreshToken = "";
     appGlobal.feedlyApiClient.accessToken = "";
+    // Nothing else drops the memo, so signing in as somebody else would otherwise
+    // label their articles with the previous account's subscription titles.
+    appGlobal.getUserSubscriptionsPromise = null;
     setInactiveStatus();
 
     try {
@@ -1262,7 +1281,7 @@ async function requestNewAccessToken(){
 
         // A grant that answers 200 without a token must not be stored, writing undefined
         // over the token would make the failure permanent.
-        if (!response || !response.access_token) {
+        if (!response?.access_token) {
             throw new Error("The refresh response contained no access token");
         }
 
@@ -1281,9 +1300,9 @@ async function requestNewAccessToken(){
         setActiveStatus();
         return response;
     } catch (response) {
-        if (response && response.status === 429) {
+        if (response?.status === 429) {
             await startRateLimitCooldown(response);
-        } else if (response && appGlobal.deadRefreshTokenStatuses.indexOf(response.status) !== -1) {
+        } else if (response && appGlobal.deadRefreshTokenStatuses.includes(response.status)) {
             console.info("The refresh token was rejected, signing out.", response.status);
             await clearStoredTokens();
         }
@@ -1313,20 +1332,20 @@ async function startRateLimitCooldown(response) {
    is the standard fallback and may hold either seconds or a date. The bounds guard against
    a missing header on one side and a value that would mute the extension on the other. */
 function parseRateLimitCooldown(response) {
-    let cooldown = NaN;
-    const headers = response && response.headers;
+    let cooldown = Number.NaN;
+    const headers = response?.headers;
 
     if (headers && typeof headers.get === "function") {
         const reset = headers.get("X-RateLimit-Reset") || headers.get("Retry-After");
         if (reset) {
             cooldown = Number(reset) * 1000;
-            if (isNaN(cooldown)) {
+            if (Number.isNaN(cooldown)) {
                 cooldown = Date.parse(reset) - Date.now();
             }
         }
     }
 
-    if (isNaN(cooldown) || cooldown <= 0) {
+    if (Number.isNaN(cooldown) || cooldown <= 0) {
         cooldown = rateLimitDefaultCooldownMs;
     }
 
@@ -1385,11 +1404,11 @@ async function readOptions() {
 async function apiRequestWrapper(methodName, settings) {
     if (!appGlobal.options.accessToken) {
         setInactiveStatus();
-        return Promise.reject(new Error("No access token available"));
+        throw new Error("No access token available");
     }
 
     if (isRateLimited()) {
-        return Promise.reject({ status: 429, message: "Rate limited by feedly" });
+        throw createRateLimitError();
     }
 
     settings = settings || {};
@@ -1400,15 +1419,37 @@ async function apiRequestWrapper(methodName, settings) {
         return response;
     } catch (response) {
         // Ahead of the 401 branch, so a 429 can never be mistaken for an expired token
-        if (response && response.status === 429) {
+        if (response?.status === 429) {
             await startRateLimitCooldown(response);
-            return Promise.reject(response);
+            throw response;
         }
 
-        if (response && response.status === 401) {
-            await refreshAccessToken();
-            return await appGlobal.feedlyApiClient.request(methodName, settings);
+        if (response?.status !== 401) {
+            throw response;
         }
-        return Promise.reject(response);
+
+        await refreshAccessToken();
+
+        /*
+         * The retry deliberately bypasses the wrapper, so it cannot loop, but it still
+         * needs the cooldown: a token can expire while the account is already close to
+         * its quota, which would otherwise leave the 429 unnoticed.
+         */
+        try {
+            return await appGlobal.feedlyApiClient.request(methodName, settings);
+        } catch (retryResponse) {
+            if (retryResponse?.status === 429) {
+                await startRateLimitCooldown(retryResponse);
+            }
+            throw retryResponse;
+        }
     }
+}
+
+/* Carries the status, so callers branch on it the way they do for a real api response. */
+function createRateLimitError() {
+    const error = new Error("Rate limited by feedly");
+    error.status = 429;
+
+    return error;
 }

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -265,7 +265,7 @@ browser.webRequest.onCompleted.addListener(function (details) {
     }
 
     // Only a subscriptions change can invalidate the memo, marking as read cannot.
-    if (details.url && details.url.includes("/v3/subscriptions")) {
+    if (details.url?.includes("/v3/subscriptions")) {
         appGlobal.getUserSubscriptionsPromise = null;
     }
 
@@ -1430,19 +1430,24 @@ async function apiRequestWrapper(methodName, settings) {
 
         await refreshAccessToken();
 
-        /*
-         * The retry deliberately bypasses the wrapper, so it cannot loop, but it still
-         * needs the cooldown: a token can expire while the account is already close to
-         * its quota, which would otherwise leave the 429 unnoticed.
-         */
-        try {
-            return await appGlobal.feedlyApiClient.request(methodName, settings);
-        } catch (retryResponse) {
-            if (retryResponse?.status === 429) {
-                await startRateLimitCooldown(retryResponse);
-            }
-            throw retryResponse;
+        return await retryAfterRefresh(methodName, settings);
+    }
+}
+
+/*
+ * The retry deliberately bypasses the wrapper, so it cannot loop, but it still needs the
+ * cooldown: a token can expire while the account is already close to its quota, which
+ * would otherwise leave the 429 unnoticed.
+ */
+async function retryAfterRefresh(methodName, settings) {
+    try {
+        return await appGlobal.feedlyApiClient.request(methodName, settings);
+    } catch (response) {
+        if (response?.status === 429) {
+            await startRateLimitCooldown(response);
         }
+
+        throw response;
     }
 }
 

--- a/test/core.api-wrapper.test.js
+++ b/test/core.api-wrapper.test.js
@@ -25,6 +25,30 @@ function scriptedClient(outcomes) {
     };
 }
 
+/**
+ * Builds an API client whose outcomes are keyed by method name rather than by call
+ * order, which is what concurrent callers need.
+ */
+function routedClient(routes) {
+    const calls = [];
+    return {
+        calls,
+        accessToken: "token",
+        request: async (method) => {
+            calls.push({ method });
+            const outcomes = routes[method];
+            if (!outcomes || outcomes.length === 0) {
+                throw new Error(`Unexpected request: ${method}`);
+            }
+            const outcome = outcomes.length === 1 ? outcomes[0] : outcomes.shift();
+            if (outcome.reject) {
+                throw outcome.reject;
+            }
+            return outcome.resolve;
+        }
+    };
+}
+
 describe("apiRequestWrapper", () => {
     let ctx;
     let browser;
@@ -106,6 +130,47 @@ describe("apiRequestWrapper", () => {
         expect(client.calls.filter(call => call.method === "auth/token")).toHaveLength(1);
     });
 
+    /*
+     * A whole update cycle fails with 401 together when the token expires. One
+     * auth/token request per in-flight call is what turned an expired token into the
+     * request storm behind issue #368.
+     */
+    it("shares one token refresh between concurrent callers", async () => {
+        appGlobal.options.accessToken = "stale";
+        appGlobal.options.refreshToken = "refresh";
+        const client = routedClient({
+            "markers/counts": [{ reject: { status: 401 } }, { resolve: { unreadcounts: [] } }],
+            "subscriptions": [{ reject: { status: 401 } }, { resolve: [] }],
+            "profile": [{ reject: { status: 401 } }, { resolve: { id: "u1" } }],
+            "auth/token": [{ resolve: { access_token: "fresh", id: "user-1" } }]
+        });
+        appGlobal.feedlyApiClient = client;
+
+        await Promise.all([
+            ctx.apiRequestWrapper("markers/counts"),
+            ctx.apiRequestWrapper("subscriptions"),
+            ctx.apiRequestWrapper("profile")
+        ]);
+
+        expect(client.calls.filter(call => call.method === "auth/token")).toHaveLength(1);
+        expect(appGlobal.options.accessToken).toBe("fresh");
+    });
+
+    it("refreshes again for a later request once the first refresh settled", async () => {
+        appGlobal.options.accessToken = "stale";
+        appGlobal.options.refreshToken = "refresh";
+        const client = routedClient({
+            "profile": [{ reject: { status: 401 } }, { resolve: { id: "u1" } }],
+            "auth/token": [{ resolve: { access_token: "fresh", id: "u1" } }]
+        });
+        appGlobal.feedlyApiClient = client;
+
+        await ctx.apiRequestWrapper("profile");
+        await ctx.refreshAccessToken();
+
+        expect(client.calls.filter(call => call.method === "auth/token")).toHaveLength(2);
+    });
+
     it("propagates non-401 failures without refreshing", async () => {
         appGlobal.options.accessToken = "token";
         appGlobal.options.refreshToken = "refresh";
@@ -136,23 +201,53 @@ describe("refreshAccessToken", () => {
         expect(browser._calls.setIcon).toEqual([appGlobal.icons.inactive]);
     });
 
-    it("goes inactive when the refresh token is rejected", async () => {
+    /*
+     * A refresh token feedly has permanently rejected cannot recover on its own. Left in
+     * storage it kept the scheduler awake, spending requests that could only fail --
+     * which is what exhausted the quota in issue #368. Deleting the tokens by hand was
+     * the workaround users found; this is that workaround, automated.
+     */
+    it.each([400, 401, 403])("clears the stored tokens when the refresh is rejected with %i", async (status) => {
+        await browser.storage.sync.set({ accessToken: "stale", refreshToken: "revoked" });
+        appGlobal.options.accessToken = "stale";
         appGlobal.options.refreshToken = "revoked";
-        appGlobal.feedlyApiClient = scriptedClient([{ reject: { status: 403 } }]);
+        appGlobal.feedlyApiClient = scriptedClient([{ reject: { status } }]);
 
-        await expect(ctx.refreshAccessToken()).rejects.toHaveProperty("status", 403);
+        await expect(ctx.refreshAccessToken()).rejects.toHaveProperty("status", status);
 
         expect(appGlobal.isLoggedIn).toBe(false);
         expect(browser._calls.setIcon).toEqual([appGlobal.icons.inactive]);
+        expect(appGlobal.options.accessToken).toBe("");
+        expect(appGlobal.options.refreshToken).toBe("");
+
+        const sync = await browser.storage.sync.get(null);
+        expect(sync).toMatchObject({ accessToken: "", refreshToken: "" });
+        const local = await browser.storage.local.get(["accessToken", "refreshToken"]);
+        expect(local).toMatchObject({ accessToken: "", refreshToken: "" });
     });
 
-    it("keeps the session alive on other failures", async () => {
+    it.each([429, 500, 503])("keeps the session and the tokens on a %i", async (status) => {
         appGlobal.options.refreshToken = "refresh";
-        appGlobal.feedlyApiClient = scriptedClient([{ reject: { status: 500 } }]);
+        appGlobal.feedlyApiClient = scriptedClient([{ reject: { status } }]);
 
-        await expect(ctx.refreshAccessToken()).rejects.toHaveProperty("status", 500);
+        await expect(ctx.refreshAccessToken()).rejects.toHaveProperty("status", status);
 
         expect(browser._calls.setIcon).toEqual([]);
+        expect(appGlobal.options.refreshToken).toBe("refresh");
+    });
+
+    /* Storing `undefined` over the token would make a one-off glitch permanent. */
+    it("rejects a grant that carries no token, without signing out", async () => {
+        appGlobal.options.accessToken = "stale";
+        appGlobal.options.refreshToken = "refresh";
+        appGlobal.feedlyApiClient = scriptedClient([{ resolve: { id: "u1" } }]);
+
+        await expect(ctx.refreshAccessToken()).rejects.toMatchObject({
+            message: "The refresh response contained no access token"
+        });
+
+        expect(appGlobal.options.accessToken).toBe("stale");
+        expect(appGlobal.options.refreshToken).toBe("refresh");
     });
 
     it("sends the refresh grant without the stale authorization header", async () => {

--- a/test/core.api-wrapper.test.js
+++ b/test/core.api-wrapper.test.js
@@ -40,7 +40,7 @@ function routedClient(routes) {
             if (!outcomes || outcomes.length === 0) {
                 throw new Error(`Unexpected request: ${method}`);
             }
-            const outcome = outcomes.length === 1 ? outcomes[0] : outcomes.shift();
+            const outcome = outcomes.shift();
             if (outcome.reject) {
                 throw outcome.reject;
             }
@@ -161,7 +161,10 @@ describe("apiRequestWrapper", () => {
         appGlobal.options.refreshToken = "refresh";
         const client = routedClient({
             "profile": [{ reject: { status: 401 } }, { resolve: { id: "u1" } }],
-            "auth/token": [{ resolve: { access_token: "fresh", id: "u1" } }]
+            "auth/token": [
+                { resolve: { access_token: "fresh", id: "u1" } },
+                { resolve: { access_token: "fresher", id: "u1" } }
+            ]
         });
         appGlobal.feedlyApiClient = client;
 
@@ -169,6 +172,23 @@ describe("apiRequestWrapper", () => {
         await ctx.refreshAccessToken();
 
         expect(client.calls.filter(call => call.method === "auth/token")).toHaveLength(2);
+    });
+
+    /* A token can expire while the account is already close to its quota. */
+    it("starts the cooldown when the retry after a refresh is rate limited", async () => {
+        appGlobal.options.accessToken = "stale";
+        appGlobal.options.refreshToken = "refresh";
+        appGlobal.feedlyApiClient = routedClient({
+            "markers/counts": [
+                { reject: { status: 401 } },
+                { reject: { status: 429, headers: { get: () => "600" } } }
+            ],
+            "auth/token": [{ resolve: { access_token: "fresh", id: "u1" } }]
+        });
+
+        await expect(ctx.apiRequestWrapper("markers/counts")).rejects.toHaveProperty("status", 429);
+
+        expect(appGlobal.rateLimitedUntil).toBeGreaterThan(Date.now());
     });
 
     it("propagates non-401 failures without refreshing", async () => {

--- a/test/core.counter.test.js
+++ b/test/core.counter.test.js
@@ -120,7 +120,7 @@ describe("makeMarkersRequest", () => {
 
     /*
      * A feed belonging to several selected categories is counted once per
-     * category, so core.js subtracts the surplus (core.js:599-614).
+     * category, so core.js subtracts the surplus (core.js:745-760).
      */
     it("subtracts a feed counted twice across two selected categories", async () => {
         appGlobal.options.isFiltersEnabled = true;
@@ -182,7 +182,7 @@ describe("makeMarkersRequest", () => {
     });
 
     /*
-     * KNOWN BEHAVIOUR (core.js:589-617): with filters enabled the summing loop
+     * KNOWN BEHAVIOUR (core.js:735-763): with filters enabled the summing loop
      * sits inside the same try block as, and after, `await
      * getUserSubscriptions()`. A failed subscription lookup therefore skips the
      * sum entirely and the badge clears rather than falling back to the

--- a/test/core.misc.test.js
+++ b/test/core.misc.test.js
@@ -54,7 +54,7 @@ describe("filterByNewFeeds", () => {
     /*
      * KNOWN BUG: parseFeeds emits `date` as a Date, but updateFeeds writes the
      * cache straight into storage where it is JSON-serialised to a string. After
-     * a service-worker restart the comparison at core.js:514 is string vs Date,
+     * a service-worker restart the comparison at core.js:648 is string vs Date,
      * which is always false, so notifications go silent until the next fetch.
      */
     it("treats feeds whose date came back from storage as a string as not new", async () => {
@@ -188,7 +188,7 @@ describe("markAsRead", () => {
     });
 
     /*
-     * KNOWN BUG (core.js:940): the badge text is read back and coerced with `+`.
+     * KNOWN BUG (core.js:1107): the badge text is read back and coerced with `+`.
      * Above 999 it reads "1k+", which coerces to NaN, so the decrement is
      * silently skipped and the badge keeps its stale value.
      */
@@ -265,6 +265,7 @@ describe("toggleSavedFeed", () => {
 describe("scheduling", () => {
     it("creates both alarms and clears them again", () => {
         const { ctx, browser, appGlobal } = loadCore();
+        appGlobal.options.accessToken = "token";
 
         ctx.startSchedule(15, true);
 
@@ -280,11 +281,25 @@ describe("scheduling", () => {
 
     it("skips the counter alarm when the badge is disabled", () => {
         const { ctx, browser, appGlobal } = loadCore();
+        appGlobal.options.accessToken = "token";
         appGlobal.options.showCounter = false;
 
         ctx.startSchedule(10, true);
 
         expect(browser._calls.alarmsCreated.map(alarm => alarm.name)).toEqual(["updateFeeds"]);
+    });
+
+    /*
+     * Signed out, every scheduled request would fail, and each failure wakes the worker
+     * again. That idle churn is part of what exhausted the api quota in issue #368.
+     */
+    it("arms no alarms without an access token", () => {
+        const { ctx, browser } = loadCore();
+
+        ctx.startSchedule(10, true);
+
+        expect(browser._calls.alarmsCreated).toEqual([]);
+        expect(browser._calls.alarmsCleared).toEqual(["updateCounter", "updateFeeds"]);
     });
 
     // A worker waking for an alarm must not recreate the alarms it woke for.

--- a/test/core.options.test.js
+++ b/test/core.options.test.js
@@ -110,7 +110,7 @@ describe("options", () => {
         });
 
         /*
-         * KNOWN BEHAVIOUR (core.js:1119): booleans go through Boolean(), so any
+         * KNOWN BEHAVIOUR (core.js:1354): booleans go through Boolean(), so any
          * non-empty string is true. A legacy record holding the string "false"
          * therefore reads back as true.
          */

--- a/test/core.rate-limit.test.js
+++ b/test/core.rate-limit.test.js
@@ -188,6 +188,73 @@ describe("signing out", () => {
     });
 });
 
+/*
+ * The quota is counted per account. A deadline that outlived the credentials it was
+ * recorded for would hold back a freshly authorised account for up to an hour.
+ */
+describe("cooldown across a credential change", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.accessToken = "token";
+        appGlobal.options.refreshToken = "refresh";
+        appGlobal.rateLimitedUntil = NOW + 30 * MINUTE;
+        await browser.storage.local.set({ rateLimitedUntil: NOW + 30 * MINUTE });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("drops the deadline when the tokens are cleared", async () => {
+        await ctx.clearStoredTokens();
+
+        expect(appGlobal.rateLimitedUntil).toBe(0);
+        expect(await browser.storage.local.get("rateLimitedUntil")).toEqual({});
+    });
+
+    it("drops the deadline when an account signs in", async () => {
+        appGlobal.feedlyApiClient = {
+            accessToken: "",
+            getMethodUrl: () => "https://cloud.feedly.com/v3/auth/auth",
+            request: async () => ({ access_token: "new", refresh_token: "r2", id: "u2" })
+        };
+
+        const signIn = ctx.getAccessToken();
+        await vi.advanceTimersByTimeAsync(0);
+        await browser.tabs.onUpdated.trigger(1, {
+            url: "https://olsh.github.io/Feedly-Notifier/?state=" + NOW + "&code=abc"
+        }, {});
+        await signIn;
+
+        expect(appGlobal.options.accessToken).toBe("new");
+        expect(appGlobal.rateLimitedUntil).toBe(0);
+    });
+
+    /* The whole point: the account that signs in afterwards can talk to feedly again. */
+    it("lets the new account read straight away", async () => {
+        await ctx.clearStoredTokens();
+        appGlobal.options.accessToken = "new";
+
+        const calls = [];
+        appGlobal.feedlyApiClient = {
+            accessToken: "new",
+            request: async (method) => {
+                calls.push(method);
+                return { id: "u2" };
+            }
+        };
+
+        await expect(ctx.apiRequestWrapper("profile")).resolves.toEqual({ id: "u2" });
+        expect(calls).toEqual(["profile"]);
+    });
+});
+
 describe("rate limited update cycle", () => {
     let ctx;
     let browser;

--- a/test/core.rate-limit.test.js
+++ b/test/core.rate-limit.test.js
@@ -112,6 +112,28 @@ describe("rate limit cooldown", () => {
         expect(client.calls).toHaveLength(1);
     });
 
+    /*
+     * The cooldown is there to stop polling, and the update cycle already stops before
+     * the wrapper. Refusing here would only block the action the user just asked for,
+     * which the popup applies optimistically and never reports as failed.
+     */
+    it("still attempts a write the user asked for", async () => {
+        await trip({ "Retry-After": "600" });
+
+        const calls = [];
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method, settings) => {
+                calls.push({ method, verb: settings.method });
+                return {};
+            }
+        };
+
+        await ctx.markAsRead(["a"]);
+
+        expect(calls).toEqual([{ method: "markers", verb: "POST" }]);
+    });
+
     it("resumes once the deadline has passed", async () => {
         await trip({ "Retry-After": "600" });
 

--- a/test/core.rate-limit.test.js
+++ b/test/core.rate-limit.test.js
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+
+/**
+ * Feedly answers 429 (HAP429) once the account has spent its api quota, and the quota is
+ * per account, so the feedly website starts failing too -- which is what issue #368
+ * reported. Polling through the ban only prolongs it.
+ */
+
+const NOW = new Date("2026-09-07T12:00:00Z").getTime();
+const MINUTE = 60 * 1000;
+
+/** A client that rejects with a 429 carrying the given headers. */
+function rateLimitedClient(headers) {
+    const calls = [];
+    return {
+        calls,
+        accessToken: "token",
+        request: async (method) => {
+            calls.push(method);
+            throw {
+                status: 429,
+                headers: {
+                    get: (name) => (headers && headers[name] !== undefined ? headers[name] : null)
+                }
+            };
+        }
+    };
+}
+
+describe("rate limit cooldown", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.accessToken = "token";
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    async function trip(headers) {
+        appGlobal.feedlyApiClient = rateLimitedClient(headers);
+        await expect(ctx.apiRequestWrapper("markers/counts")).rejects.toHaveProperty("status", 429);
+        return appGlobal.feedlyApiClient;
+    }
+
+    it("takes the cooldown from X-RateLimit-Reset", async () => {
+        await trip({ "X-RateLimit-Reset": "1800" });
+
+        expect(appGlobal.rateLimitedUntil).toBe(NOW + 30 * MINUTE);
+    });
+
+    it("falls back to Retry-After in seconds", async () => {
+        await trip({ "Retry-After": "600" });
+
+        expect(appGlobal.rateLimitedUntil).toBe(NOW + 10 * MINUTE);
+    });
+
+    it("accepts an http date in Retry-After", async () => {
+        await trip({ "Retry-After": new Date(NOW + 20 * MINUTE).toUTCString() });
+
+        expect(appGlobal.rateLimitedUntil).toBe(NOW + 20 * MINUTE);
+    });
+
+    it("defaults to fifteen minutes when the response says nothing", async () => {
+        await trip();
+
+        expect(appGlobal.rateLimitedUntil).toBe(NOW + 15 * MINUTE);
+    });
+
+    it("defaults when the header cannot be parsed", async () => {
+        await trip({ "Retry-After": "soon" });
+
+        expect(appGlobal.rateLimitedUntil).toBe(NOW + 15 * MINUTE);
+    });
+
+    /* A tiny value would restore the request storm the cooldown exists to stop. */
+    it("never waits less than a minute", async () => {
+        await trip({ "Retry-After": "1" });
+
+        expect(appGlobal.rateLimitedUntil).toBe(NOW + MINUTE);
+    });
+
+    /* A bogus value must not mute the extension for days. */
+    it("never waits more than an hour", async () => {
+        await trip({ "X-RateLimit-Reset": "999999" });
+
+        expect(appGlobal.rateLimitedUntil).toBe(NOW + 60 * MINUTE);
+    });
+
+    it("persists the deadline so a fresh worker honours it", async () => {
+        await trip({ "Retry-After": "600" });
+
+        const stored = await browser.storage.local.get("rateLimitedUntil");
+        expect(stored.rateLimitedUntil).toBe(NOW + 10 * MINUTE);
+    });
+
+    it("skips further requests while the cooldown is active", async () => {
+        const client = await trip({ "Retry-After": "600" });
+        expect(client.calls).toHaveLength(1);
+
+        await expect(ctx.apiRequestWrapper("subscriptions")).rejects.toHaveProperty("status", 429);
+        await expect(ctx.apiRequestWrapper("profile")).rejects.toHaveProperty("status", 429);
+
+        expect(client.calls).toHaveLength(1);
+    });
+
+    it("resumes once the deadline has passed", async () => {
+        await trip({ "Retry-After": "600" });
+
+        vi.setSystemTime(NOW + 11 * MINUTE);
+        const calls = [];
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method) => {
+                calls.push(method);
+                return { id: "user-1" };
+            }
+        };
+
+        await expect(ctx.apiRequestWrapper("profile")).resolves.toEqual({ id: "user-1" });
+        expect(calls).toEqual(["profile"]);
+    });
+
+    /* A rate limited refresh is temporary, signing the user out would be wrong. */
+    it("never mistakes a 429 for an expired token", async () => {
+        appGlobal.options.refreshToken = "refresh";
+        const client = await trip({ "Retry-After": "600" });
+
+        expect(client.calls).toEqual(["markers/counts"]);
+        expect(appGlobal.options.refreshToken).toBe("refresh");
+        expect(appGlobal.options.accessToken).toBe("token");
+    });
+
+    it("does not sign out when the refresh itself is rate limited", async () => {
+        appGlobal.options.refreshToken = "refresh";
+        appGlobal.feedlyApiClient = rateLimitedClient({ "Retry-After": "600" });
+
+        await expect(ctx.refreshAccessToken()).rejects.toHaveProperty("status", 429);
+
+        expect(appGlobal.options.refreshToken).toBe("refresh");
+        expect(appGlobal.rateLimitedUntil).toBe(NOW + 10 * MINUTE);
+    });
+});
+
+describe("rate limited update cycle", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.accessToken = "token";
+        appGlobal.options.feedlyUserId = "u1";
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    /*
+     * The count is unknown during a cooldown, and blanking the badge would throw the last
+     * good value away for the whole of it.
+     */
+    it("keeps the badge when feedly rate limits the counter", async () => {
+        appGlobal.feedlyApiClient = rateLimitedClient({ "Retry-After": "600" });
+
+        await ctx.updateCounter();
+
+        expect(browser._calls.setBadgeText).toEqual([]);
+    });
+
+    it("still clears the badge on an ordinary failure", async () => {
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => {
+                throw { status: 500 };
+            }
+        };
+
+        await ctx.updateCounter();
+
+        expect(browser._calls.setBadgeText).toContain("");
+    });
+
+    it("makes no requests at all while the cooldown is active", async () => {
+        const calls = [];
+        appGlobal.rateLimitedUntil = NOW + 10 * MINUTE;
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method) => {
+                calls.push(method);
+                return {};
+            }
+        };
+
+        await ctx.updateCounter();
+        await ctx.updateFeeds();
+        await ctx.updateSavedFeeds();
+
+        expect(calls).toEqual([]);
+    });
+
+    it("restores the cooldown from storage when the worker wakes", async () => {
+        const { ctx: freshCtx, appGlobal: freshGlobal } = loadCore({
+            storage: {
+                sync: { accessToken: "token" },
+                local: { rateLimitedUntil: NOW + 10 * MINUTE }
+            }
+        });
+
+        await freshCtx.readOptions();
+
+        expect(freshGlobal.rateLimitedUntil).toBe(NOW + 10 * MINUTE);
+
+        const calls = [];
+        freshGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method) => {
+                calls.push(method);
+                return {};
+            }
+        };
+
+        await expect(freshCtx.apiRequestWrapper("profile")).rejects.toHaveProperty("status", 429);
+        expect(calls).toEqual([]);
+    });
+});

--- a/test/core.rate-limit.test.js
+++ b/test/core.rate-limit.test.js
@@ -150,6 +150,22 @@ describe("rate limit cooldown", () => {
     });
 });
 
+describe("signing out", () => {
+    /*
+     * Nothing else resets the memo, so signing in as a different account in the same
+     * worker would label their articles with the previous account's subscription titles.
+     */
+    it("drops the cached subscriptions", async () => {
+        const { ctx, appGlobal } = loadCore();
+        appGlobal.options.accessToken = "token";
+        appGlobal.getUserSubscriptionsPromise = Promise.resolve([]);
+
+        await ctx.clearStoredTokens();
+
+        expect(appGlobal.getUserSubscriptionsPromise).toBeNull();
+    });
+});
+
 describe("rate limited update cycle", () => {
     let ctx;
     let browser;

--- a/test/core.storage-changed.test.js
+++ b/test/core.storage-changed.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+
+/**
+ * Every access token refresh writes the token back to storage. Reacting to that write by
+ * reinitialising restarted the scheduler and fired another update -- once per refresh,
+ * and a whole update cycle can refresh at once. That feedback loop is the largest of the
+ * amplifiers behind issue #368.
+ *
+ * initialize() always calls setPopup, so setPopup is the signal that it ran.
+ */
+
+/** A client that records what was asked for and answers with empty payloads. */
+function recordingClient() {
+    const calls = [];
+    return {
+        calls,
+        accessToken: "token",
+        request: async (method) => {
+            calls.push(method);
+            return { unreadcounts: [], items: [], id: "u1" };
+        }
+    };
+}
+
+describe("storage change handling", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+    let client;
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore({
+            storage: { sync: { accessToken: "token", updateInterval: 10 } }
+        }));
+        client = recordingClient();
+        appGlobal.feedlyApiClient = client;
+    });
+
+    async function change(items, changes) {
+        await browser.storage.sync.set(items);
+        await browser.storage.onChanged.trigger(changes || items);
+    }
+
+    function reinitialised() {
+        return browser._calls.setPopup.length > 0;
+    }
+
+    it("ignores a feed cache write", async () => {
+        await browser.storage.onChanged.trigger({ cachedFeeds: { newValue: [] } });
+
+        expect(reinitialised()).toBe(false);
+        // readOptions did not run either, so the seeded option is still unread.
+        expect(appGlobal.options.accessToken).toBe("");
+    });
+
+    it("ignores the rate limit deadline it writes itself", async () => {
+        await browser.storage.onChanged.trigger({ rateLimitedUntil: { newValue: 123 } });
+
+        expect(reinitialised()).toBe(false);
+    });
+
+    it("re-reads the options for a non critical option without restarting", async () => {
+        await ctx.readOptions();
+
+        await change({ theme: "dark" });
+
+        expect(appGlobal.options.theme).toBe("dark");
+        expect(reinitialised()).toBe(false);
+    });
+
+    it("restarts the schedule when the update interval really changes", async () => {
+        await change({ updateInterval: 45 });
+
+        expect(reinitialised()).toBe(true);
+        expect(browser._calls.alarmsCreated[0].info).toEqual({ periodInMinutes: 45 });
+    });
+
+    it("does not restart when an option is rewritten with the same value", async () => {
+        await ctx.readOptions();
+
+        await change({ updateInterval: 10, showCounter: true });
+
+        expect(reinitialised()).toBe(false);
+    });
+
+    /* The filters are an array, so identity comparison would report a change every time. */
+    it("treats an equal filters array as unchanged", async () => {
+        await browser.storage.sync.set({ filters: ["a", "b"] });
+        await ctx.readOptions();
+
+        await change({ filters: ["a", "b"] });
+
+        expect(reinitialised()).toBe(false);
+    });
+
+    it("adopts a refreshed access token without restarting the schedule", async () => {
+        await ctx.readOptions();
+
+        await change({ accessToken: "fresh" });
+
+        expect(reinitialised()).toBe(false);
+        expect(browser._calls.alarmsCreated).toEqual([]);
+        expect(client.calls).toEqual([]);
+        expect(appGlobal.feedlyApiClient.accessToken).toBe("fresh");
+    });
+
+    it("starts the schedule when a token first appears", async () => {
+        await browser.storage.sync.set({ accessToken: "" });
+        await ctx.readOptions();
+
+        await change({ accessToken: "token" });
+
+        expect(reinitialised()).toBe(true);
+        expect(browser._calls.alarmsCreated.map(alarm => alarm.name))
+            .toEqual(["updateCounter", "updateFeeds"]);
+    });
+
+    it("goes quiet when the token is cleared", async () => {
+        await ctx.readOptions();
+
+        await change({ accessToken: "" });
+
+        expect(reinitialised()).toBe(true);
+        expect(browser._calls.alarmsCreated).toEqual([]);
+        expect(client.calls).toEqual([]);
+    });
+
+    /*
+     * Signing out writes both storage areas one after the other. Deciding from the
+     * reported change rather than the resolved options would act on the first write while
+     * the area the options are read from still held a live token.
+     */
+    it("does not restart for a write to the area the options are not read from", async () => {
+        await ctx.readOptions();
+
+        await browser.storage.local.set({ accessToken: "" });
+        await browser.storage.onChanged.trigger({ accessToken: { oldValue: "token", newValue: "" } });
+
+        expect(reinitialised()).toBe(false);
+        expect(appGlobal.options.accessToken).toBe("token");
+    });
+});

--- a/test/core.storage-changed.test.js
+++ b/test/core.storage-changed.test.js
@@ -77,6 +77,18 @@ describe("storage change handling", () => {
         expect(browser._calls.alarmsCreated[0].info).toEqual({ periodInMinutes: 45 });
     });
 
+    /*
+     * startSchedule decides whether to create the updateFeeds alarm from both of these,
+     * so a change to either has to rebuild it.
+     */
+    it.each(["showDesktopNotifications", "playSound"])("restarts the schedule when %s changes", async (optionName) => {
+        await ctx.readOptions();
+
+        await change({ [optionName]: false });
+
+        expect(reinitialised()).toBe(true);
+    });
+
     it("does not restart when an option is rewritten with the same value", async () => {
         await ctx.readOptions();
 

--- a/test/core.update-feeds.test.js
+++ b/test/core.update-feeds.test.js
@@ -87,7 +87,7 @@ describe("updateFeeds", () => {
 
     /*
      * The dedup filter drops an entry when a later copy exists, so the *last*
-     * occurrence survives (core.js:665-672). Which stream's copy wins matters,
+     * occurrence survives (core.js:815-822). Which stream's copy wins matters,
      * because the metadata can differ between them.
      */
     it("keeps the last copy of an item present in several streams", async () => {

--- a/test/core.web-request.test.js
+++ b/test/core.web-request.test.js
@@ -135,31 +135,62 @@ describe("saved feeds listener", () => {
     let saved;
 
     beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-09-07T12:00:00Z"));
+
         ({ ctx, browser } = loadCore({ storage: { sync: { accessToken: "token" } } }));
+
         saved = 0;
-        // The real one is async, and the listener attaches a catch to what it returns.
+        // The real one is async, and the throttle attaches a catch to what it returns.
         ctx.updateSavedFeeds = async () => { saved++; };
         ctx.updateCounter = () => {};
         ctx.updateFeeds = () => {};
     });
 
-    it("updates when the website saves a feed", async () => {
-        await browser.webRequest.onCompleted.trigger(websiteEvent({
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    async function fire(details) {
+        await browser.webRequest.onCompleted.trigger(websiteEvent(Object.assign({
             method: "PUT",
             url: "https://cloud.feedly.com/v3/tags/user%2F1%2Ftag%2Fglobal.saved"
-        }));
+        }, details)));
+        await vi.advanceTimersByTimeAsync(0);
+    }
+
+    it("updates when the website saves a feed", async () => {
+        await fire();
 
         expect(saved).toBe(1);
     });
 
     it("ignores the extension's own save", async () => {
-        await browser.webRequest.onCompleted.trigger(websiteEvent({
-            method: "PUT",
-            url: "https://cloud.feedly.com/v3/tags/user%2F1%2Ftag%2Fglobal.saved",
-            initiator: EXTENSION_ORIGIN.replace(/\/$/, ""),
-            tabId: -1
-        }));
+        await fire({ initiator: EXTENSION_ORIGIN.replace(/\/$/, ""), tabId: -1 });
 
         expect(saved).toBe(0);
+    });
+
+    /* Saving in bulk would otherwise spend one stream request per article. */
+    it("collapses a burst into one leading and one trailing update", async () => {
+        for (let i = 0; i < 6; i++) {
+            await fire();
+        }
+
+        expect(saved).toBe(1);
+
+        await vi.advanceTimersByTimeAsync(WINDOW_MS);
+
+        expect(saved).toBe(2);
+    });
+
+    /* Each throttle keeps its own timer, so one cannot postpone the other. */
+    it("does not share its window with the counter update", async () => {
+        await browser.webRequest.onCompleted.trigger(websiteEvent());
+        await vi.advanceTimersByTimeAsync(0);
+
+        await fire();
+
+        expect(saved).toBe(1);
     });
 });

--- a/test/core.web-request.test.js
+++ b/test/core.web-request.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { loadCore } from "./helpers/load-core.js";
+
+/**
+ * The feedly website posts to /v3/markers once per article, and it marks them as the
+ * user scrolls, so a page of reading used to cost a full update per article. These
+ * tests pin the throttle and the own-request filter that issue #368 needed.
+ *
+ * updateCounter and updateFeeds are replaced on the context rather than stubbed at the
+ * api client: they are top level function declarations, so they live on the vm global
+ * and the listener resolves them there at call time.
+ */
+
+const EXTENSION_ORIGIN = "chrome-extension://feedly-notifier-test/";
+const WINDOW_MS = 20000;
+
+function websiteEvent(overrides) {
+    return Object.assign({
+        method: "POST",
+        url: "https://cloud.feedly.com/v3/markers",
+        tabId: 7,
+        initiator: "https://feedly.com"
+    }, overrides);
+}
+
+describe("feedly website listener", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+    let updates;
+
+    beforeEach(() => {
+        // The sandbox captures setTimeout when the context is built, so the fake timers
+        // have to be installed before loadCore.
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-09-07T12:00:00Z"));
+
+        ({ ctx, browser, appGlobal } = loadCore({ storage: { sync: { accessToken: "token" } } }));
+
+        updates = [];
+        ctx.updateCounter = () => updates.push("counter");
+        ctx.updateFeeds = () => updates.push("feeds");
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    async function fire(details) {
+        await browser.webRequest.onCompleted.trigger(websiteEvent(details));
+        // ensureOptionsLoaded awaits storage before the updates run.
+        await vi.advanceTimersByTimeAsync(0);
+    }
+
+    it("updates immediately for the first website request", async () => {
+        await fire();
+
+        expect(updates).toEqual(["counter", "feeds"]);
+    });
+
+    it("collapses a burst into one leading and one trailing update", async () => {
+        for (let i = 0; i < 10; i++) {
+            await fire();
+        }
+
+        expect(updates).toEqual(["counter", "feeds"]);
+
+        await vi.advanceTimersByTimeAsync(WINDOW_MS);
+
+        expect(updates).toEqual(["counter", "feeds", "counter", "feeds"]);
+    });
+
+    it("opens a new window once the current one has elapsed", async () => {
+        await fire();
+
+        // A lone event has nothing to coalesce, so no trailing update is armed.
+        await vi.advanceTimersByTimeAsync(WINDOW_MS);
+        expect(updates).toHaveLength(2);
+
+        await fire();
+
+        expect(updates).toHaveLength(4);
+    });
+
+    it("ignores the extension's own request reported by initiator", async () => {
+        await fire({ initiator: EXTENSION_ORIGIN.replace(/\/$/, ""), tabId: -1 });
+
+        expect(updates).toEqual([]);
+    });
+
+    it("ignores the extension's own request reported by originUrl", async () => {
+        await fire({ initiator: undefined, originUrl: EXTENSION_ORIGIN + "scripts/background.js", tabId: -1 });
+
+        expect(updates).toEqual([]);
+    });
+
+    /*
+     * The feedly website is a progressive web app, so its own service worker posts
+     * without a tab. Filtering on tabId would have silently disabled the listener for
+     * exactly the users who reported the bug.
+     */
+    it("still updates for a website request made without a tab", async () => {
+        await fire({ tabId: -1 });
+
+        expect(updates).toEqual(["counter", "feeds"]);
+    });
+
+    it("ignores requests that do not change anything", async () => {
+        await fire({ method: "GET" });
+
+        expect(updates).toEqual([]);
+    });
+
+    it("keeps the subscriptions cache when entries are marked as read", async () => {
+        appGlobal.getUserSubscriptionsPromise = Promise.resolve([]);
+
+        await fire();
+
+        expect(appGlobal.getUserSubscriptionsPromise).not.toBeNull();
+    });
+
+    it("drops the subscriptions cache when the subscriptions change", async () => {
+        appGlobal.getUserSubscriptionsPromise = Promise.resolve([]);
+
+        await fire({ url: "https://cloud.feedly.com/v3/subscriptions" });
+
+        expect(appGlobal.getUserSubscriptionsPromise).toBeNull();
+    });
+});
+
+describe("saved feeds listener", () => {
+    let ctx;
+    let browser;
+    let saved;
+
+    beforeEach(() => {
+        ({ ctx, browser } = loadCore({ storage: { sync: { accessToken: "token" } } }));
+        saved = 0;
+        // The real one is async, and the listener attaches a catch to what it returns.
+        ctx.updateSavedFeeds = async () => { saved++; };
+        ctx.updateCounter = () => {};
+        ctx.updateFeeds = () => {};
+    });
+
+    it("updates when the website saves a feed", async () => {
+        await browser.webRequest.onCompleted.trigger(websiteEvent({
+            method: "PUT",
+            url: "https://cloud.feedly.com/v3/tags/user%2F1%2Ftag%2Fglobal.saved"
+        }));
+
+        expect(saved).toBe(1);
+    });
+
+    it("ignores the extension's own save", async () => {
+        await browser.webRequest.onCompleted.trigger(websiteEvent({
+            method: "PUT",
+            url: "https://cloud.feedly.com/v3/tags/user%2F1%2Ftag%2Fglobal.saved",
+            initiator: EXTENSION_ORIGIN.replace(/\/$/, ""),
+            tabId: -1
+        }));
+
+        expect(saved).toBe(0);
+    });
+});

--- a/test/helpers/browser-mock.js
+++ b/test/helpers/browser-mock.js
@@ -104,6 +104,9 @@ function createBrowserMock(overrides) {
 
         runtime: {
             getManifest: () => ({ version: options.version || "3.2.0" }),
+            /* Real extensions get "chrome-extension://<id>/"; core.js compares request
+               initiators against it to recognise its own traffic. */
+            getURL: (path) => "chrome-extension://feedly-notifier-test/" + (path || ""),
             getPlatformInfo: async () => ({ os: options.os || "win" }),
             sendMessage: async (message) => {
                 calls.messagesSent.push(message);


### PR DESCRIPTION
Fixes #368.

## User-visible change

Feedly answers `429 (HAP429)` once an account has spent its API quota, and the quota is per account — which is why feedly.com itself started failing for the people who reported this, and why disabling the extension made it stop.

The extension was spending far more API requests than it needed to, along six separate paths. Two of them were unbounded, which is why several users could only recover by deleting `accessToken` and `refreshToken` from sync storage by hand and signing in again. The extension now does that for them, and stops generating the traffic in the first place.

> **Note for release:** this raises `minimum_chrome_version` from 88 to **114**, so it drops users below Chrome 114 from updates. See "Minimum browser version" below.

## What was spending the requests

**Reading on feedly.com.** `webRequest.onCompleted` ran a full `updateCounter()` + `updateFeeds()` for every `POST /v3/markers`. Feedly marks entries as read as you scroll, so a page of reading cost an update per article — matching the reporter's "the more tabs open, the likelier it is". Bursts now collapse into one leading and one trailing update per 20 s window. Saved-feed changes get the same treatment, with their own timer so neither can postpone the other.

**The extension triggering itself.** That listener also matched the extension's *own* `markers`/`tags` requests, so marking read from the popup kicked off an update it had already done locally. Our own requests are now recognised by `initiator` (`originUrl` on Firefox) and ignored. `details.tabId` is deliberately *not* used — feedly.com is a PWA and its own service worker posts with no tab, so a tabId filter would have silently broken the listener for exactly these users. There's a regression test pinning that.

**The subscriptions memo.** Marking as read also dropped `getUserSubscriptionsPromise`, so every burst refetched the whole subscription list. Only a `/v3/subscriptions` change invalidates it now.

**Parallel token refreshes.** `updateFeeds` asks for one stream per filtered category in parallel, so an expired token failed all of them at once and *each* failure asked for its own new token. The refresh is now shared between concurrent callers. Measured against the mock server: a cycle over three categories used to send **3** `auth/token` requests, now sends **1**.

**The refresh → reinitialise → poll loop.** Every refresh wrote the token to storage; `storage.onChanged` saw a critical option change, rebuilt the schedule and fired *another* immediate update, whose requests could expire again. Reinitialisation is now decided by comparing the resolved options, so a rotated token is adopted without restarting anything — while signing in, signing out and genuine option changes still reinitialise as before. Comparing resolved values (rather than `changes[key].oldValue`) also keeps sign-out correct, since it writes the two storage areas one after the other. `showDesktopNotifications` and `playSound` joined `criticalOptionNames`, because `startSchedule` reads both to decide whether to create the `updateFeeds` alarm.

**A permanently dead refresh token.** This was only detected as `403`, but RFC 6749 §5.2 mandates `400 invalid_grant` for an expired or revoked refresh token. On 400/401 the extension kept the schedule running and retried forever, spending requests on every alarm that could only ever fail. `400`, `401` and `403` now clear the stored tokens and stop the schedule; the icon goes inactive and clicking it starts the sign-in flow again. `429` and 5xx are still treated as temporary and never sign the user out.

## Handling 429 itself

429 wasn't handled anywhere, so once rate limited the extension kept polling at the same rate and prolonged the ban. It now pauses for as long as `X-RateLimit-Reset` or `Retry-After` asks — clamped to between a minute and an hour, defaulting to 15 minutes — persisted so a fresh service worker honours it. The badge keeps its last known count rather than blanking, since a quota pause is not a sign-out.

Two things the cooldown deliberately does *not* do:

- **It never holds back a write.** The polling entry points all return before reaching the request wrapper, so a check there would only ever block the action the user just asked for — which the popup applies optimistically. Reads are held back; a write that Feedly still refuses comes back as a 429 that refreshes the deadline anyway.
- **It never outlives its credentials.** The quota belongs to the account, so the deadline is cleared whenever credentials change. Otherwise the sign-out this PR introduces would leave a freshly authorised account throttled for up to an hour — and an entirely different account had never hit the quota at all.

## Minimum browser version

`minimum_chrome_version` was 88 while the code already used `storage.session` (Chrome 102) and the side panel (Chrome 114) behind guards, so older versions silently lost those features instead of being told they were unsupported. It now declares **114**, which is what the extension actually needs. Firefox is unchanged at `strict_min_version: 115.0`, and the Firefox build carries no `minimum_chrome_version` (verified). Note the non-Firefox manifest branch also covers the Opera build.

## Tests

`npm run lint`, `npm test` (275 unit) and `npm run test:e2e` (43 e2e) all pass.

New: `test/core.web-request.test.js`, `test/core.rate-limit.test.js`, `test/core.storage-changed.test.js`, and `e2e/quota-protection.spec.js`; `test/core.api-wrapper.test.js` gains single-flight and dead-token coverage. The e2e mock server gained `failTimes` / `failAlways` and header support, since the existing `failNext` was one-shot and could not send `Retry-After`.

Verified these pin the fix rather than merely passing: against the previous `core.js`, 29 of the new unit tests and all 4 new e2e tests fail.

Two existing scheduling tests in `test/core.misc.test.js` now seed an access token, because `startSchedule` no longer arms alarms without one (a signed-out extension used to wake every 10 minutes to make requests that could only fail). Several `KNOWN BUG` / `KNOWN BEHAVIOUR` annotations cite `core.js` line numbers that this change shifts, so those references were re-pointed.

## Browsers tested

Chromium via the automated e2e suite. `npx grunt sandbox --browser=firefox` builds and parses, and the Firefox `originUrl` path is covered by a unit test, but the Firefox build was not manually loaded — worth a manual check of the own-request filter there before release.

## Trade-off

Marking as read on feedly.com now reaches the badge in up to ~20 s instead of instantly (worst case ~40 s for the last action in a burst), against up to 10 minutes if the throttle is dropped. The trailing update uses `setTimeout`; the 20 s window keeps it inside the MV3 keepalive, and if the worker is torn down first the badge just waits for the next alarm. A `browser.alarms`-backed trailing run would be teardown-proof but has a 1-minute floor, which felt worse for the common case.
