### PR TITLE
Show the extension in the browser sidebar

### DIFF
--- a/e2e/popup-actions.spec.js
+++ b/e2e/popup-actions.spec.js
@@ -30,6 +30,11 @@ test.describe("popup actions", () => {
         await signIn();
 
         const page = await popupPage();
+        /* Unlike the per-article buttons, #mark-all-read is in the static markup and is
+           already clickable when goto() returns, before the popup has rendered anything.
+           Clicking it then marks the empty list, so wait for the articles first. */
+        await expect(page.locator("#feed .item")).toHaveCount(3);
+
         await page.locator("#mark-all-read").click();
 
         await expect.poll(() => mockApi.requestsTo("/v3/markers", "POST").length).toBeGreaterThan(0);

--- a/e2e/side-panel.spec.js
+++ b/e2e/side-panel.spec.js
@@ -16,6 +16,16 @@ test.describe("side panel", () => {
         return serviceWorker.evaluate(() => chrome.sidePanel.getOptions({}));
     }
 
+    /*
+     * getOptions() answers with the manifest's own defaults until the worker overrides
+     * them, so reading it straight away would pass whatever the worker went on to do.
+     * ensureInitialized() is the worker's memoised boot promise: awaiting it puts the
+     * read after configureSidePanel(), which is the call under test.
+     */
+    function settled(serviceWorker) {
+        return serviceWorker.evaluate(() => globalThis.ensureInitialized());
+    }
+
     test("declares the panel in the manifest", async ({ serviceWorker }) => {
         const manifest = await serviceWorker.evaluate(() => chrome.runtime.getManifest());
 
@@ -31,7 +41,9 @@ test.describe("side panel", () => {
      * browser's sidebar. Nothing here touches the options page.
      */
     test("offers the panel out of the box", async ({ serviceWorker }) => {
-        await expect.poll(() => panelOptions(serviceWorker)).toMatchObject({
+        await settled(serviceWorker);
+
+        expect(await panelOptions(serviceWorker)).toEqual({
             enabled: true,
             path: "popup.html?panel=1"
         });
@@ -39,16 +51,17 @@ test.describe("side panel", () => {
 
     test("still offers the panel once signed in", async ({ signIn, serviceWorker }) => {
         await signIn();
+        await settled(serviceWorker);
 
-        await expect.poll(() => panelOptions(serviceWorker)).toMatchObject({ enabled: true });
+        expect(await panelOptions(serviceWorker)).toMatchObject({ enabled: true });
     });
 
     test("leaves the toolbar icon on the popup by default", async ({ signIn, serviceWorker }) => {
         await signIn();
+        await settled(serviceWorker);
 
-        await expect
-            .poll(() => serviceWorker.evaluate(() => chrome.action.getPopup({})))
-            .toContain("popup.html");
+        const popup = await serviceWorker.evaluate(() => chrome.action.getPopup({}));
+        expect(popup).toContain("popup.html");
     });
 
     test("hands the toolbar icon to the panel when the option is on", async ({ signIn, optionsPage, serviceWorker }) => {
@@ -58,11 +71,15 @@ test.describe("side panel", () => {
         await page.locator("#enableSidePanel").check();
         await page.locator("#save").click();
 
-        // A popup would take precedence over the panel, so it has to be dropped.
+        /* Saving reaches the worker through storage.onChanged, which re-runs the boot
+           work outside the promise settled() waits on, so poll for it to land. A popup
+           would take precedence over the panel, so it has to be dropped. */
         await expect
             .poll(() => serviceWorker.evaluate(() => chrome.action.getPopup({})))
             .toBe("");
-        await expect.poll(() => panelOptions(serviceWorker)).toMatchObject({ enabled: true });
+
+        // Handing the icon over must not cost the browser's own sidebar entry.
+        expect(await panelOptions(serviceWorker)).toMatchObject({ enabled: true });
     });
 
     test("renders the feeds in the panel layout", async ({ mockApi, signIn, popupPage }) => {

--- a/e2e/side-panel.spec.js
+++ b/e2e/side-panel.spec.js
@@ -1,0 +1,114 @@
+const { test, expect } = require("./fixtures/extension");
+const { item, SUBSCRIPTIONS, GLOBAL_ALL } = require("./fixtures/feed-items");
+
+/**
+ * The side panel is what Microsoft Edge lists in its sidebar (issue #297). Playwright
+ * cannot drive the browser's sidebar UI, so these tests assert the state that UI reads:
+ * the panel's registration, and the page it loads behaving as a panel.
+ */
+test.describe("side panel", () => {
+    test.beforeEach(async ({ mockApi }) => {
+        mockApi.subscriptions = SUBSCRIPTIONS;
+    });
+
+    /** What the browser reads to decide whether to offer the extension in its sidebar. */
+    function panelOptions(serviceWorker) {
+        return serviceWorker.evaluate(() => chrome.sidePanel.getOptions({}));
+    }
+
+    test("declares the panel in the manifest", async ({ serviceWorker }) => {
+        const manifest = await serviceWorker.evaluate(() => chrome.runtime.getManifest());
+
+        expect(manifest.permissions).toContain("sidePanel");
+        expect(manifest.side_panel.default_path).toBe("popup.html?panel=1");
+        // sidePanel.open() is Chrome 116+, and the worker calls it unguarded.
+        expect(manifest.minimum_chrome_version).toBe("116");
+    });
+
+    /*
+     * The regression test for #297: the extension used to disable its own panel
+     * whenever the option was off, which is how an extension removes itself from the
+     * browser's sidebar. Nothing here touches the options page.
+     */
+    test("offers the panel out of the box", async ({ serviceWorker }) => {
+        await expect.poll(() => panelOptions(serviceWorker)).toMatchObject({
+            enabled: true,
+            path: "popup.html?panel=1"
+        });
+    });
+
+    test("still offers the panel once signed in", async ({ signIn, serviceWorker }) => {
+        await signIn();
+
+        await expect.poll(() => panelOptions(serviceWorker)).toMatchObject({ enabled: true });
+    });
+
+    test("leaves the toolbar icon on the popup by default", async ({ signIn, serviceWorker }) => {
+        await signIn();
+
+        await expect
+            .poll(() => serviceWorker.evaluate(() => chrome.action.getPopup({})))
+            .toContain("popup.html");
+    });
+
+    test("hands the toolbar icon to the panel when the option is on", async ({ signIn, optionsPage, serviceWorker }) => {
+        await signIn();
+        const page = await optionsPage();
+
+        await page.locator("#enableSidePanel").check();
+        await page.locator("#save").click();
+
+        // A popup would take precedence over the panel, so it has to be dropped.
+        await expect
+            .poll(() => serviceWorker.evaluate(() => chrome.action.getPopup({})))
+            .toBe("");
+        await expect.poll(() => panelOptions(serviceWorker)).toMatchObject({ enabled: true });
+    });
+
+    test("renders the feeds in the panel layout", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a"), item("b")]);
+        await signIn();
+
+        const page = await popupPage("?panel=1");
+
+        await expect(page.locator("#feed .item")).toHaveCount(2);
+
+        // The browser sizes the panel, so the popup's fixed width has to give way to it.
+        const layout = await page.evaluate(() => ({
+            body: document.body.style.width,
+            content: document.getElementById("popup-content").style.width
+        }));
+        expect(layout).toEqual({ body: "100%", content: "100%" });
+    });
+
+    /*
+     * The point of the request was an extension pinned open, which only works if it
+     * follows the worker's scheduled updates instead of the state it was opened in.
+     */
+    test("picks up new articles while it stays open", async ({ mockApi, signIn, popupPage, serviceWorker }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a")]);
+        await signIn();
+
+        const page = await popupPage("?panel=1");
+        await expect(page.locator("#feed .item")).toHaveCount(1);
+
+        mockApi.setStream(GLOBAL_ALL, [item("a"), item("b"), item("c")]);
+        await serviceWorker.evaluate(() => globalThis.updateFeeds());
+
+        await expect(page.locator("#feed .item")).toHaveCount(3);
+    });
+
+    test("leaves the popup alone when the worker updates", async ({ mockApi, signIn, popupPage, serviceWorker }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a")]);
+        await signIn();
+
+        const page = await popupPage();
+        await expect(page.locator("#feed .item")).toHaveCount(1);
+
+        mockApi.setStream(GLOBAL_ALL, [item("a"), item("b")]);
+        await serviceWorker.evaluate(() => globalThis.updateFeeds());
+
+        // Re-rendering under the user's cursor would be worse than a stale list.
+        await expect(page.locator("#feed .item")).toHaveCount(1);
+    });
+});

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -30,7 +30,7 @@
     "message": "Enable background mode"
   },
   "EnableSidePanel": {
-    "message": "Enable side panel (same as popup)"
+    "message": "Open the side panel instead of the popup"
   },
   "EngagementFilterLimit": {
     "message": "Mark articles as read if engagement less than"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -75,7 +75,7 @@
     ],
 
     // @if BROWSER!='firefox'
-    "minimum_chrome_version": "114",
+    "minimum_chrome_version": "116",
     // @endif
     // @if BROWSER='firefox'
     "applications": {

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -397,42 +397,45 @@ async function initialize(immediate) {
     startSchedule(appGlobal.options.updateInterval, immediate);
 }
 
-/* Returns true when the side panel is enabled and the browser accepted the configuration */
+/* The page the browser loads into its sidebar. Must stay in sync with the
+   side_panel.default_path key in manifest.json: the manifest is what makes the browser
+   list the extension before the worker has ever run, this is what it uses afterwards. */
+const SIDE_PANEL_PATH = "popup.html?panel=1";
+
+/* Registers the side panel and reports whether the toolbar icon now opens it.
+
+   The panel itself is always left enabled. `enabled: false` is how an extension takes
+   itself out of the browser's sidebar UI, and the Edge sidebar is meant to be opened
+   from the browser rather than unlocked by an extension setting (issue #297), so the
+   option below decides only what the toolbar icon does, never whether the panel exists. */
 async function configureSidePanel() {
-    if (!browser.sidePanel || typeof browser.sidePanel.setOptions !== "function") {
+    //Firefox has sidebar_action instead, and Opera ships no implementation at all.
+    if (!browser.sidePanel) {
         return false;
     }
 
-    const isEnabled = Boolean(appGlobal.options.enableSidePanel);
-    let isConfigured = false;
+    const opensOnActionClick = Boolean(appGlobal.options.enableSidePanel);
 
     try {
         await browser.sidePanel.setOptions({
-            enabled: isEnabled,
-            path: "popup.html?panel=1"
+            enabled: true,
+            path: SIDE_PANEL_PATH
         });
-        isConfigured = true;
+        await browser.sidePanel.setPanelBehavior({openPanelOnActionClick: opensOnActionClick});
     } catch (e) {
+        //Reported as not configured, so the caller keeps the popup: an icon that opens
+        //neither the panel nor the popup would leave the extension unreachable.
         console.info("Unable to configure side panel", e);
+        return false;
     }
 
-    //Set separately, a failure above must not leave the icon without any behaviour
-    if (typeof browser.sidePanel.setPanelBehavior === "function") {
-        try {
-            await browser.sidePanel.setPanelBehavior({openPanelOnActionClick: isEnabled});
-            isConfigured = true;
-        } catch (e) {
-            console.info("Unable to set side panel behaviour", e);
-        }
-    }
-
-    return isEnabled && isConfigured;
+    return opensOnActionClick;
 }
 
 /* Opens the side panel for the clicked tab. Deliberately not async, awaiting the call
    would move it out of the user gesture that the browser requires. */
 function openSidePanel(tab) {
-    if (!browser.sidePanel || typeof browser.sidePanel.open !== "function") {
+    if (!browser.sidePanel) {
         return false;
     }
 
@@ -686,6 +689,28 @@ async function resetCounter(){
     await browser.storage.local.set({ lastCounterResetTime: new Date().getTime() });
 }
 
+/* Identifies a cache by the articles in it. The sidebar is refreshed when articles come
+   or go, not when their engagement rate drifts under them. */
+function feedIdsSignature(feeds) {
+    return JSON.stringify(feeds.map(function (feed) {
+        return feed.id;
+    }));
+}
+
+/* Tells an open sidebar or side panel that the cache moved on. The toolbar popup renders
+   itself every time it opens and needs nothing, but a panel the user has pinned would
+   otherwise keep showing whatever was current when they pinned it (issue #297).
+
+   Only sent when the articles actually changed, which is also what keeps it from looping:
+   getFeeds() updates the feeds whenever the cache is empty, so an unconditional message
+   would have a panel with nothing unread triggering an update on every round.
+
+   Nothing is listening when no extension page is open and sendMessage rejects in that
+   case, so that rejection is the normal path rather than a failure. */
+function notifyFeedsUpdated() {
+    browser.runtime.sendMessage({type: "feedsUpdated"}).catch(function () {});
+}
+
 /**
  * Updates saved feeds and stores them in cache.
  * @returns {Promise}
@@ -695,10 +720,14 @@ async function updateSavedFeeds() {
         return;
     }
 
+    const previousSignature = feedIdsSignature(appGlobal.cachedSavedFeeds);
     const response = await apiRequestWrapper("streams/" + encodeURIComponent(appGlobal.savedGroup) + "/contents");
     const feeds = await parseFeeds(response);
     appGlobal.cachedSavedFeeds = feeds;
     browser.storage.local.set({ cachedSavedFeeds: feeds }).catch(function () {});
+    if (feedIdsSignature(feeds) !== previousSignature) {
+        notifyFeedsUpdated();
+    }
 }
 
 /* Sets badge counter if unread feeds more than zero */
@@ -878,6 +907,9 @@ async function updateFeeds(silentUpdate) {
         newCache = newCache.splice(0, appGlobal.options.maxNumberOfFeeds);
         appGlobal.cachedFeeds = newCache;
         browser.storage.local.set({ cachedFeeds: newCache }).catch(function () {});
+        if (feedIdsSignature(newCache) !== feedIdsSignature(previousCache)) {
+            notifyFeedsUpdated();
+        }
         if (!silentUpdate && (appGlobal.options.showDesktopNotifications)) {
             const newFeeds = await filterByNewFeeds(appGlobal.cachedFeeds);
             await sendDesktopNotification(newFeeds);

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -79,7 +79,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 //the worker, and any promise returned from here would race with the worker's own reply.
 //Returning undefined leaves those messages to it.
 browser.runtime.onMessage.addListener(function (message) {
-    if (message && message.type === "feedsUpdated") {
+    if (message?.type === "feedsUpdated") {
         renderFromCache();
     }
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -75,6 +75,40 @@ document.addEventListener("DOMContentLoaded", async function () {
     executeAsync(renderFeeds);
 });
 
+//Deliberately not async: this listener also sees the messages the options page sends to
+//the worker, and any promise returned from here would race with the worker's own reply.
+//Returning undefined leaves those messages to it.
+browser.runtime.onMessage.addListener(function (message) {
+    if (message && message.type === "feedsUpdated") {
+        renderFromCache();
+    }
+
+    return undefined;
+});
+
+/* Follows the background's scheduled updates while the page stays open. Only the sidebar
+   and the side panel need it: the popup is opened, read and closed again, whereas a pinned
+   panel would otherwise go on showing the articles that were current when it was pinned
+   (issue #297). Renders from the cache the background has just filled, spending a request
+   of our own here would undo the quota protection. */
+function renderFromCache() {
+    if (!popupGlobal.isSidebar) {
+        return;
+    }
+
+    //Re-rendering collapses whatever the user has open, so a page being read is left as
+    //it is. Not a signal when expandFeeds expands every article by itself.
+    if (!options.expandFeeds && $(".content").is(":visible")) {
+        return;
+    }
+
+    if (options.abilitySaveFeeds && $("#tabs-checkbox").is(":checked")) {
+        renderSavedFeeds(false, true);
+    } else {
+        renderFeeds(false, true);
+    }
+}
+
 $("#login").on("click", async function () {
     await bg.send("getAccessToken");
     renderFeeds();
@@ -265,10 +299,11 @@ function executeAsync(func) {
     }, timeout);
 }
 
-async function renderFeeds(forceUpdate) {
-    showLoader();
-    const wantForce = (options.forceUpdateFeeds || forceUpdate);
-    const result = await bg.send("getFeeds", { forceUpdate: wantForce });
+async function renderFeeds(forceUpdate = options.forceUpdateFeeds, isSilent = false) {
+    if (!isSilent) {
+        showLoader();
+    }
+    const result = await bg.send("getFeeds", { forceUpdate: Boolean(forceUpdate) });
     const feeds = result && result.feeds || [];
     const isLoggedIn = result && result.isLoggedIn;
     popupGlobal.feeds = feeds;
@@ -299,10 +334,11 @@ async function renderFeeds(forceUpdate) {
     }
 }
 
-async function renderSavedFeeds(forceUpdate) {
-    showLoader();
-    const wantForce = (options.forceUpdateFeeds || forceUpdate);
-    const result = await bg.send("getSavedFeeds", { forceUpdate: wantForce });
+async function renderSavedFeeds(forceUpdate = options.forceUpdateFeeds, isSilent = false) {
+    if (!isSilent) {
+        showLoader();
+    }
+    const result = await bg.send("getSavedFeeds", { forceUpdate: Boolean(forceUpdate) });
     const feeds = result && result.feeds || [];
     const isLoggedIn = result && result.isLoggedIn;
     popupGlobal.savedFeeds = feeds;

--- a/test/core.side-panel.test.js
+++ b/test/core.side-panel.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+
+import { loadBackground } from "./helpers/load-core.js";
+
+/**
+ * The side panel is what Microsoft Edge lists in its sidebar (issue #297), so the
+ * extension has to register it whether or not the user wants the toolbar icon to open
+ * it. `enabled: false` is how an extension removes itself from the browser's sidebar
+ * UI -- it is not a way to say "configured but unused".
+ */
+describe("side panel", () => {
+    describe("registration", () => {
+        it("registers the panel even though the option is off by default", async () => {
+            const { browser, ready } = loadBackground();
+
+            await ready();
+
+            expect(browser._calls.sidePanelOptions).toContainEqual({
+                enabled: true,
+                path: "popup.html?panel=1"
+            });
+        });
+
+        it("registers the panel with the option on", async () => {
+            const { browser, ready } = loadBackground({
+                storage: { sync: { enableSidePanel: true } }
+            });
+
+            await ready();
+
+            expect(browser._calls.sidePanelOptions).toContainEqual({
+                enabled: true,
+                path: "popup.html?panel=1"
+            });
+        });
+
+        it("never disables the panel", async () => {
+            const { browser, ready } = loadBackground();
+
+            await ready();
+
+            const disabling = browser._calls.sidePanelOptions.filter(call => call.enabled === false);
+            expect(disabling).toEqual([]);
+        });
+
+        it("registers the path the manifest declares", async () => {
+            const { browser, ready } = loadBackground();
+
+            await ready();
+
+            // The manifest is what the browser reads before the worker has ever run;
+            // this call is what it reads afterwards. They have to agree.
+            expect(browser._calls.sidePanelOptions[0].path).toBe("popup.html?panel=1");
+        });
+    });
+
+    describe("toolbar icon behaviour", () => {
+        it("leaves the icon on the popup by default", async () => {
+            const { browser, ready } = loadBackground();
+
+            await ready();
+
+            expect(browser._calls.sidePanelBehavior).toContainEqual({ openPanelOnActionClick: false });
+            expect(browser._calls.setPopup).toContain("popup.html");
+            expect(browser._calls.setPopup).not.toContain("");
+        });
+
+        it("hands the icon to the panel when the option is on", async () => {
+            const { browser, ready } = loadBackground({
+                storage: { sync: { enableSidePanel: true } }
+            });
+
+            await ready();
+
+            expect(browser._calls.sidePanelBehavior).toContainEqual({ openPanelOnActionClick: true });
+            expect(browser._calls.setPopup).toContain("");
+        });
+
+        /* An icon that opens neither the panel nor the popup would leave the extension
+           with no UI at all, so a browser that refuses the API keeps the popup. */
+        it("keeps the popup when the browser refuses to configure the panel", async () => {
+            const { browser, ready } = loadBackground({
+                sidePanelSetOptionsFails: true,
+                storage: { sync: { enableSidePanel: true } }
+            });
+
+            await ready();
+
+            expect(browser._calls.setPopup).toContain("popup.html");
+        });
+
+        it("keeps the popup when the browser refuses the panel behaviour", async () => {
+            const { browser, ready } = loadBackground({
+                sidePanelSetBehaviorFails: true,
+                storage: { sync: { enableSidePanel: true } }
+            });
+
+            await ready();
+
+            expect(browser._calls.setPopup).toContain("popup.html");
+        });
+
+        /* Firefox has sidebar_action instead, and core.js is shared with that build. */
+        it("does nothing on a browser with no side panel API", async () => {
+            const { browser, ready } = loadBackground({
+                sidePanel: false,
+                storage: { sync: { enableSidePanel: true } }
+            });
+
+            await ready();
+
+            expect(browser._calls.setPopup).toContain("popup.html");
+        });
+    });
+
+    describe("opening from the action click", () => {
+        it("opens the panel for the clicked tab", async () => {
+            const { browser, ready } = loadBackground({
+                storage: { sync: { enableSidePanel: true, accessToken: "token" } }
+            });
+            await ready();
+
+            await browser._events["action.onClicked"][0]({ id: 7, windowId: 3 });
+
+            expect(browser._calls.sidePanelOpened).toContainEqual({ tabId: 7 });
+            // Opening the panel replaces opening the website, not doubles up with it.
+            expect(browser._calls.tabsCreated).toEqual([]);
+        });
+
+        it("falls back to the window when the click carries no tab id", async () => {
+            const { browser, ready } = loadBackground({
+                storage: { sync: { enableSidePanel: true, accessToken: "token" } }
+            });
+            await ready();
+
+            await browser._events["action.onClicked"][0]({ windowId: 3 });
+
+            expect(browser._calls.sidePanelOpened).toContainEqual({ windowId: 3 });
+        });
+
+        it("leaves the click alone when the option is off", async () => {
+            const { browser, ready } = loadBackground({
+                storage: { sync: { accessToken: "token" } }
+            });
+            await ready();
+
+            await browser._events["action.onClicked"][0]({ id: 7, windowId: 3 });
+
+            expect(browser._calls.sidePanelOpened).toEqual([]);
+        });
+    });
+});

--- a/test/core.update-feeds.test.js
+++ b/test/core.update-feeds.test.js
@@ -256,3 +256,109 @@ describe("getFeeds", () => {
         expect(requests).toBeGreaterThan(0);
     });
 });
+
+/**
+ * A sidebar or side panel stays open for hours, so the worker tells it when the cache
+ * moved on (issue #297). Only when the articles actually changed: getFeeds() updates
+ * whenever the cache is empty, so an unconditional message would have a panel with
+ * nothing unread triggering an update on every round.
+ */
+describe("feedsUpdated broadcast", () => {
+    let ctx;
+    let browser;
+    let appGlobal;
+
+    /** Every message the worker broadcast, ignoring anything else it sent. */
+    function broadcasts() {
+        return browser._calls.messagesSent.filter(message => message.type === "feedsUpdated");
+    }
+
+    function stubGlobalStream(items) {
+        appGlobal.options.accessToken = "token";
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method) => {
+                if (method === "subscriptions") {
+                    return [];
+                }
+                return { items };
+            }
+        };
+    }
+
+    beforeEach(() => {
+        ({ ctx, browser, appGlobal } = loadCore());
+        appGlobal.options.feedlyUserId = "u1";
+    });
+
+    it("announces articles arriving", async () => {
+        stubGlobalStream([entry("a")]);
+
+        await ctx.updateFeeds(true);
+
+        expect(broadcasts()).toHaveLength(1);
+    });
+
+    it("stays quiet when the same articles come back", async () => {
+        stubGlobalStream([entry("a")]);
+        await ctx.updateFeeds(true);
+        browser._calls.messagesSent.length = 0;
+
+        await ctx.updateFeeds(true);
+
+        expect(broadcasts()).toEqual([]);
+    });
+
+    /* The loop this guards against: an empty cache makes getFeeds() update, so a message
+       on every update would have the panel asking for another one straight away. */
+    it("stays quiet when there was nothing unread and still is not", async () => {
+        stubGlobalStream([]);
+
+        await ctx.updateFeeds(true);
+
+        expect(broadcasts()).toEqual([]);
+    });
+
+    it("announces the last article being read", async () => {
+        stubGlobalStream([entry("a")]);
+        await ctx.updateFeeds(true);
+        browser._calls.messagesSent.length = 0;
+        stubGlobalStream([]);
+
+        await ctx.updateFeeds(true);
+
+        expect(broadcasts()).toHaveLength(1);
+    });
+
+    it("stays quiet when the update fails", async () => {
+        appGlobal.options.accessToken = "token";
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async () => {
+                throw new Error("network down");
+            }
+        };
+
+        await ctx.updateFeeds(true);
+
+        expect(broadcasts()).toEqual([]);
+    });
+
+    it("announces saved articles changing", async () => {
+        stubGlobalStream([entry("saved")]);
+
+        await ctx.updateSavedFeeds();
+
+        expect(broadcasts()).toHaveLength(1);
+    });
+
+    it("stays quiet when the saved articles are unchanged", async () => {
+        stubGlobalStream([entry("saved")]);
+        await ctx.updateSavedFeeds();
+        browser._calls.messagesSent.length = 0;
+
+        await ctx.updateSavedFeeds();
+
+        expect(broadcasts()).toEqual([]);
+    });
+});

--- a/test/helpers/browser-mock.js
+++ b/test/helpers/browser-mock.js
@@ -93,7 +93,10 @@ function createBrowserMock(overrides) {
         tabsCreated: [],
         tabsUpdated: [],
         windowsCreated: [],
-        messagesSent: []
+        messagesSent: [],
+        sidePanelOptions: [],
+        sidePanelBehavior: [],
+        sidePanelOpened: []
     };
 
     let badgeText = "";
@@ -201,12 +204,25 @@ function createBrowserMock(overrides) {
         }
     };
 
-    /* Chromium-only surfaces. Omitted when simulating Firefox. */
+    /* Chromium-only surfaces. Omitted when simulating Firefox, which has sidebarAction
+       instead, and when simulating a Chromium without a side panel implementation. */
     if (options.sidePanel !== false) {
         browser.sidePanel = {
-            setOptions: async () => undefined,
-            setPanelBehavior: async () => undefined,
-            open: async () => undefined
+            setOptions: async (panelOptions) => {
+                calls.sidePanelOptions.push(panelOptions);
+                if (options.sidePanelSetOptionsFails) {
+                    throw new Error("setOptions refused");
+                }
+            },
+            setPanelBehavior: async (behavior) => {
+                calls.sidePanelBehavior.push(behavior);
+                if (options.sidePanelSetBehaviorFails) {
+                    throw new Error("setPanelBehavior refused");
+                }
+            },
+            open: async (target) => {
+                calls.sidePanelOpened.push(target);
+            }
         };
     }
 

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -11,7 +11,9 @@ const POPUP_EXPORTS = [
     "executeAsync",
     "options",
     "environment",
-    "bg"
+    "bg",
+    "popupGlobal",
+    "renderFromCache"
 ];
 
 async function loadPopup(overrides = {}) {
@@ -177,5 +179,85 @@ describe("popup page", () => {
             await new Promise(resolve => setTimeout(resolve, 600));
             expect(ran).toBe(true);
         });
+    });
+});
+
+/**
+ * A pinned sidebar or side panel has to follow the worker's scheduled updates, which the
+ * worker announces by broadcasting to every extension page (issue #297). The toolbar
+ * popup receives the same message and must ignore it -- it renders on open, and
+ * re-rendering under the user's cursor would be worse than showing a stale list.
+ */
+describe("feedsUpdated broadcast", () => {
+    let popup;
+    let browser;
+
+    /** Every request the page made of the worker. */
+    function sent() {
+        return browser._calls.messagesSent;
+    }
+
+    beforeEach(async () => {
+        ({ page: popup, browser } = await loadPopup());
+        sent().length = 0;
+    });
+
+    function broadcast(message) {
+        return browser._events["runtime.onMessage"][0](message, {});
+    }
+
+    it("listens for messages from the worker", () => {
+        expect(browser._events["runtime.onMessage"]).toHaveLength(1);
+    });
+
+    /* An async listener would return a promise for every message, including the ones the
+       options page sends to the worker, and race with the worker's own reply. */
+    it("claims no message it does not handle", () => {
+        expect(broadcast({ type: "getOptions" })).toBeUndefined();
+        expect(broadcast({ type: "feedsUpdated" })).toBeUndefined();
+        expect(broadcast(null)).toBeUndefined();
+    });
+
+    it("ignores unrelated messages", () => {
+        broadcast({ type: "getOptions" });
+
+        expect(sent()).toEqual([]);
+    });
+
+    it("ignores the broadcast in the popup", () => {
+        popup.popupGlobal.isSidebar = false;
+
+        broadcast({ type: "feedsUpdated" });
+
+        expect(sent()).toEqual([]);
+    });
+
+    it("re-reads the cache in the sidebar", () => {
+        popup.popupGlobal.isSidebar = true;
+
+        broadcast({ type: "feedsUpdated" });
+
+        expect(sent()).toEqual([{ type: "getFeeds", forceUpdate: false }]);
+    });
+
+    /* The worker has just finished an update; asking for another one would undo the
+       quota protection, and forceUpdateFeeds must not drag the panel into one either. */
+    it("never forces an update, whatever the option says", () => {
+        popup.popupGlobal.isSidebar = true;
+        popup.options.forceUpdateFeeds = true;
+
+        popup.renderFromCache();
+
+        expect(sent()).toEqual([{ type: "getFeeds", forceUpdate: false }]);
+    });
+
+    it("re-reads the saved articles when that tab is showing", () => {
+        popup.popupGlobal.isSidebar = true;
+        popup.options.abilitySaveFeeds = true;
+        $("#tabs-checkbox").prop("checked", true);
+
+        popup.renderFromCache();
+
+        expect(sent()).toEqual([{ type: "getSavedFeeds", forceUpdate: false }]);
     });
 });

--- a/test/preprocess.test.js
+++ b/test/preprocess.test.js
@@ -67,6 +67,8 @@ describe("line-preserving preprocessor", () => {
         expect(chromeManifest.manifest_version).toBe(3);
         expect(chromeManifest.permissions).toContain("sidePanel");
         expect(chromeManifest.side_panel).toBeDefined();
+        // sidePanel.open() is Chrome 116+, and core.js calls it unguarded.
+        expect(chromeManifest.minimum_chrome_version).toBe("116");
 
         expect(firefoxManifest.permissions).not.toContain("sidePanel");
         expect(firefoxManifest.sidebar_action).toBeDefined();


### PR DESCRIPTION
Closes #297.

## The problem

Edge implements its sidebar with the same surface as Chrome — the `side_panel` manifest key, the `sidePanel` permission and `chrome.sidePanel` — and #356 already ships all of that in every non-Firefox build. The manifest half of #297 was done.

The worker was undoing it. `configureSidePanel()` called `setOptions({enabled: appGlobal.options.enableSidePanel, …})` on every boot, and that option is off by default. `enabled: false` with no `tabId` is precisely how an extension takes itself out of the browser's sidebar UI, so Feedly Notifier never appeared in Edge's **Customize sidebar** list or Chrome's side panel picker. The only way in was an options checkbox that *also* took the toolbar icon away from the popup — not what someone pinning a sidebar wants.

Second gap: `popup.js` renders once on `DOMContentLoaded` and nothing pushed feed changes from the worker. Fine for a popup, wrong for a panel left open for hours, which is the whole point of the request. The Firefox sidebar had the same defect.

## The change

**The panel is always available.** `setOptions({enabled: true, path})` unconditionally, the way `sidebar_action` has always worked in Firefox. `enableSidePanel` now decides only `openPanelOnActionClick`. Both calls share one try/catch, so a browser that refuses either keeps the popup rather than leaving the icon dead.

**`minimum_chrome_version` 114 → 116.** `sidePanel.open()` is documented as Chrome 116+ and the worker calls it, so 114 was below what the code needs. The per-method `typeof` capability checks came out with it; only the `!browser.sidePanel` check that Firefox and Opera actually need remains.

**A pinned panel keeps up.** The worker announces cache changes and the sidebar re-renders from the cache it has just filled — no extra request, so #385's quota work stays intact. Only when the article ids changed, which is load-bearing rather than tidy: `getFeeds()` updates whenever the cache is empty, so an unconditional message would have a panel with nothing unread triggering an update every round. The popup ignores the announcement (re-rendering under the cursor is worse than a stale list), and an expanded article is left alone. This fixes the Firefox sidebar too.

**Wording.** The English label becomes "Open the side panel instead of the popup"; the checkbox no longer enables anything. The 28 translations keep the older phrasing until they are redone.

## Note on behaviour

Existing Chrome users will now see the extension in the side panel picker whether or not they tick the option. That is the point of the change, but it is visible and new.

## Tests

`test/core.side-panel.test.js` is new and covers registration, the icon behaviour, the API-refused fallback and a Firefox-shaped browser. `e2e/side-panel.spec.js` asserts what the browser actually reads: `chrome.sidePanel.getOptions({})` returns `{enabled: true, path: "popup.html?panel=1"}` straight after install with the options page never opened — the regression test for this issue — and that a panel picks up new articles with no click while a popup does not.

One unrelated fix rode along. `e2e/popup-actions.spec.js` *"marks everything as read"* started failing. It passes on master, so I checked whether it was mine: it is not. `#mark-all-read` is in the static markup and already clickable when `goto()` returns, so the click could land before anything had rendered and mark an empty list. This change shifts startup timing enough to lose that race. It now waits for the articles first, the way its sibling tests already do.

## Verified

- `npm run lint`, `npm test` (301 pass), `npm run test:e2e` (51 pass)
- `npx grunt build` for `chrome`, `firefox` and `opera`, with the generated manifests checked: chrome gets `side_panel` + `sidePanel` + `minimum_chrome_version: 116`, firefox gets `sidebar_action` and none of the above
- Not yet exercised in Edge itself by hand — worth a pass through **Customize sidebar** before release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added side-panel support with toolbar actions that open the panel or popup according to settings.
  * Feed views now update automatically when saved or unread article membership changes.
  * Added popup fallback when side-panel functionality is unavailable or fails.

* **Improvements**
  * Clarified side-panel configuration wording.
  * Chrome 116 or later is now required.

* **Tests**
  * Expanded coverage for side-panel behavior, live feed updates, fallback handling, and mark-all-as-read actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->