### PR TITLE
Collapse the CI browser matrix into one job

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -38,8 +38,10 @@ jobs:
             #
             # Dummy credentials, like the e2e build: string-replace substitutes
             # whatever it is handed, so the real secrets would prove nothing here,
-            # and this way the job also runs on pull requests from forks.
-            - run: npx grunt build --clientId=ci-client-id --clientSecret=ci-client-secret --browser=firefox
+            # and this way the job also runs on pull requests from forks. The
+            # locally installed grunt rather than `npx`, which would be free to
+            # fetch an unpinned package on demand and run its lifecycle scripts.
+            - run: ./node_modules/.bin/grunt build --clientId=ci-client-id --clientSecret=ci-client-secret --browser=firefox
 
     # Kept separate from `test`: this job needs a Playwright browser download and
     # a different build, and it is worth seeing which of the two failed. The build

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -35,7 +35,11 @@ jobs:
             # than chrome because the e2e job already builds chrome -- and through the
             # `default` task, so it never zips. What each target actually resolves to is
             # validated in test/preprocess.test.js.
-            - run: npx grunt build --clientId=${{ secrets.FEEDLY_CLIENT_ID }} --clientSecret=${{ secrets.FEEDLY_CLIENT_SECRET }} --browser=firefox
+            #
+            # Dummy credentials, like the e2e build: string-replace substitutes
+            # whatever it is handed, so the real secrets would prove nothing here,
+            # and this way the job also runs on pull requests from forks.
+            - run: npx grunt build --clientId=ci-client-id --clientSecret=ci-client-secret --browser=firefox
 
     # Kept separate from `test`: this job needs a Playwright browser download and
     # a different build, and it is worth seeing which of the two failed. The build

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,10 +8,6 @@ permissions: {}
 
 jobs:
     test:
-        strategy:
-            fail-fast: false
-            matrix:
-                browser: ["chrome", "opera", "firefox"]
         runs-on: ubuntu-latest
 
         permissions:
@@ -31,10 +27,18 @@ jobs:
             - run: npm install
             - run: npm run lint
             - run: npm test
-            - run: npx grunt build --clientId=${{ secrets.FEEDLY_CLIENT_ID }} --clientSecret=${{ secrets.FEEDLY_CLIENT_SECRET }} --browser=${{ matrix.browser }}
 
-    # Separate from the browser matrix: the extension only side-loads into
-    # Chromium, so running this three times would add no coverage. The build
+            # One build proves the copy/preprocess/zip pipeline runs. Building each
+            # browser in turn adds nothing: the only per-browser failure mode is an
+            # unbalanced @if/@endif, and `preprocess` scans every directive whatever
+            # BROWSER it is resolving, so it throws for all three alike. firefox rather
+            # than chrome because the e2e job already builds chrome -- and through the
+            # `default` task, so it never zips. What each target actually resolves to is
+            # validated in test/preprocess.test.js.
+            - run: npx grunt build --clientId=${{ secrets.FEEDLY_CLIENT_ID }} --clientSecret=${{ secrets.FEEDLY_CLIENT_SECRET }} --browser=firefox
+
+    # Kept separate from `test`: this job needs a Playwright browser download and
+    # a different build, and it is worth seeing which of the two failed. The build
     # uses dummy credentials rather than the repository secrets, because the
     # suite never exercises the real OAuth flow -- which also lets it run on
     # pull requests from forks.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,16 +70,6 @@ module.exports = function (grunt) {
                 }
             }
         },
-        uglify: {
-            dist: {
-                files: {
-                    "<%= pkg.buildPath %>/scripts/core.js": ["<%= pkg.buildPath %>/scripts/core.js"],
-                    "<%= pkg.buildPath %>/scripts/feedly.api.js": ["<%= pkg.buildPath %>/scripts/feedly.api.js"],
-                    "<%= pkg.buildPath %>/scripts/options.js": ["<%= pkg.buildPath %>/scripts/options.js"],
-                    "<%= pkg.buildPath %>/scripts/popup.js": ["<%= pkg.buildPath %>/scripts/popup.js"]
-                }
-            }
-        },
         zip: {
             build: {
                 cwd: "<%= pkg.buildPath %>/",

--- a/test/preprocess.test.js
+++ b/test/preprocess.test.js
@@ -161,6 +161,11 @@ describe("manifest.json", () => {
  * suite only ever compiles the chrome target, because loadCore and
  * loadBackground default `targetBrowser` to "chrome". So this is the only check
  * that the opera and firefox packages contain valid JS.
+ *
+ * Unlike every other suite, this one runs the real `preprocess` package rather
+ * than the line-preserving helper: the point is to parse the exact bytes the
+ * zip would carry. The two are pinned together above, so this cannot drift, and
+ * a failure here means the shipped file is broken rather than the stand-in.
  */
 describe("preprocessed scripts", () => {
     it("found the shipped scripts", () => {
@@ -170,7 +175,8 @@ describe("preprocessed scripts", () => {
     describe.each(BROWSERS)("for %s", (targetBrowser) => {
         it.each(SHIPPED_SCRIPTS)("compiles %s", (name) => {
             const filename = path.join(scriptsDir, name);
-            const processed = preprocessPreservingLines(readFileSync(filename, "utf8"), targetBrowser);
+            const source = readFileSync(filename, "utf8");
+            const processed = preprocess(source, { BROWSER: targetBrowser }, { type: "js" });
 
             /*
              * Compiling this repository's own source: checked-in input, never

--- a/test/preprocess.test.js
+++ b/test/preprocess.test.js
@@ -1,16 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+import { Script } from "node:vm";
 import path from "node:path";
 import { preprocess } from "preprocess";
 
 import { preprocessPreservingLines } from "./helpers/preprocess.js";
-import { projectRoot } from "./helpers/load-core.js";
+import { projectRoot, scriptsDir } from "./helpers/load-core.js";
 
 /**
  * The unit suites evaluate a line-preserving preprocessing of src/, so that
  * coverage and stack traces line up with the real files. These tests pin that
  * implementation against the `preprocess` package the Grunt build actually
  * uses, so the two can never silently diverge.
+ *
+ * They are also the only place the build's output is ever inspected. The
+ * pipeline is copy -> string-replace -> preprocess -> zip and it parses nothing
+ * it produces, so a directive branch that resolves to broken JSON or
+ * unparseable JS would be packaged and shipped without complaint.
  */
 const BROWSERS = ["chrome", "opera", "firefox"];
 
@@ -18,8 +24,26 @@ const PREPROCESSED_FILES = [
     "src/scripts/core.js",
     "src/scripts/feedly.api.js",
     "src/scripts/popup.js",
-    "src/manifest.json"
+    "src/manifest.json",
+    // The only file written with the `<!-- @if -->` form, and the only one with
+    // an opera-specific branch. popup.html carries no directives at all.
+    "src/options.html"
 ];
+
+/**
+ * Every shipped script, read from disk so that one added later is covered
+ * without touching this file. src/scripts/ holds only first-party code -- the
+ * vendor libraries are copied straight out of node_modules by the Gruntfile.
+ */
+const SHIPPED_SCRIPTS = readdirSync(scriptsDir).filter(name => name.endsWith(".js"));
+
+/**
+ * Mirrors the Gruntfile: `build/scripts/*.js` and `build/*.json` go through the
+ * `js` parser, `build/*.html` through the html one.
+ */
+function preprocessType(relativePath) {
+    return relativePath.endsWith(".html") ? "html" : "js";
+}
 
 /** Both tools agree only up to the blank lines one of them leaves behind. */
 function significantLines(text) {
@@ -32,7 +56,7 @@ describe("line-preserving preprocessor", () => {
             const source = readFileSync(path.join(projectRoot, relativePath), "utf8");
 
             const ours = preprocessPreservingLines(source, targetBrowser);
-            const theirs = preprocess(source, { BROWSER: targetBrowser }, { type: "js" });
+            const theirs = preprocess(source, { BROWSER: targetBrowser }, { type: preprocessType(relativePath) });
 
             expect(significantLines(ours)).toEqual(significantLines(theirs));
         });
@@ -55,26 +79,6 @@ describe("line-preserving preprocessor", () => {
         expect(processed[originalLine]).toContain("browserPrefix = \"c\"");
     });
 
-    it("resolves manifest.json into valid JSON", () => {
-        const source = readFileSync(path.join(projectRoot, "src/manifest.json"), "utf8");
-
-        // The raw file is not parseable: it carries // comments and directives.
-        expect(() => JSON.parse(source)).toThrow();
-
-        const chromeManifest = JSON.parse(stripComments(preprocessPreservingLines(source, "chrome")));
-        const firefoxManifest = JSON.parse(stripComments(preprocessPreservingLines(source, "firefox")));
-
-        expect(chromeManifest.manifest_version).toBe(3);
-        expect(chromeManifest.permissions).toContain("sidePanel");
-        expect(chromeManifest.side_panel).toBeDefined();
-        // sidePanel.open() is Chrome 116+, and core.js calls it unguarded.
-        expect(chromeManifest.minimum_chrome_version).toBe("116");
-
-        expect(firefoxManifest.permissions).not.toContain("sidePanel");
-        expect(firefoxManifest.sidebar_action).toBeDefined();
-        expect(firefoxManifest.applications.gecko.strict_min_version).toBe("115.0");
-    });
-
     it("selects a different branch for each browser", () => {
         const source = readFileSync(path.join(projectRoot, "src/scripts/feedly.api.js"), "utf8");
 
@@ -89,6 +93,98 @@ describe("line-preserving preprocessor", () => {
         expect(() => preprocessPreservingLines("// @if BROWSER='chrome'\n", "chrome")).toThrow(/Unclosed/);
     });
 });
+
+describe("manifest.json", () => {
+    const source = readFileSync(path.join(projectRoot, "src/manifest.json"), "utf8");
+
+    it("is not parseable before preprocessing", () => {
+        // The raw file carries // comments and directives.
+        expect(() => JSON.parse(source)).toThrow();
+    });
+
+    /*
+     * Dropping a directive branch can leave JSON that is invalid, or merely
+     * gutted, and the build zips either without complaint -- so the keys every
+     * target has to keep are asserted alongside the parse.
+     */
+    it.each(BROWSERS)("resolves into valid JSON for %s", (targetBrowser) => {
+        const manifest = parseManifest(source, targetBrowser);
+
+        expect(manifest.manifest_version).toBe(3);
+        expect(manifest.name).toBe("Feedly Notifier");
+        expect(manifest.background.service_worker).toBe("scripts/background.js");
+        expect(manifest.host_permissions).toContain("*://*.feedly.com/*");
+        expect(manifest.action.default_popup).toBe("popup.html");
+    });
+
+    /*
+     * Every directive in the manifest is keyed on firefox, so the two Chromium
+     * targets resolve identically. Opera ships no side panel implementation but
+     * gets the keys anyway: core.js guards on `browser.sidePanel` at runtime
+     * rather than on BROWSER at build time.
+     */
+    it.each(["chrome", "opera"])("gives %s the side panel keys", (targetBrowser) => {
+        const manifest = parseManifest(source, targetBrowser);
+
+        expect(manifest.permissions).toContain("sidePanel");
+        expect(manifest.side_panel).toBeDefined();
+        expect(manifest.sidebar_action).toBeUndefined();
+        // sidePanel.open() is Chrome 116+, and core.js calls it unguarded.
+        expect(manifest.minimum_chrome_version).toBe("116");
+    });
+
+    it("gives firefox the sidebar keys instead", () => {
+        const manifest = parseManifest(source, "firefox");
+
+        expect(manifest.permissions).not.toContain("sidePanel");
+        expect(manifest.side_panel).toBeUndefined();
+        expect(manifest.sidebar_action).toBeDefined();
+        expect(manifest.minimum_chrome_version).toBeUndefined();
+        expect(manifest.applications.gecko.strict_min_version).toBe("115.0");
+    });
+
+    /*
+     * The side panel page is named twice -- once for the browser to read before
+     * the worker has ever run, once for core.js to reopen it afterwards -- and
+     * nothing in the build compares the two. See the note above SIDE_PANEL_PATH.
+     */
+    it("points the side panel at the path core.js opens", () => {
+        const coreSource = readFileSync(path.join(projectRoot, "src/scripts/core.js"), "utf8");
+        const manifest = parseManifest(source, "chrome");
+
+        expect(coreSource).toContain(`SIDE_PANEL_PATH = "${manifest.side_panel.default_path}"`);
+    });
+});
+
+/*
+ * Nothing in the build parses the JavaScript it ships, and the rest of this
+ * suite only ever compiles the chrome target, because loadCore and
+ * loadBackground default `targetBrowser` to "chrome". So this is the only check
+ * that the opera and firefox packages contain valid JS.
+ */
+describe("preprocessed scripts", () => {
+    it("found the shipped scripts", () => {
+        expect(SHIPPED_SCRIPTS).toContain("core.js");
+    });
+
+    describe.each(BROWSERS)("for %s", (targetBrowser) => {
+        it.each(SHIPPED_SCRIPTS)("compiles %s", (name) => {
+            const filename = path.join(scriptsDir, name);
+            const processed = preprocessPreservingLines(readFileSync(filename, "utf8"), targetBrowser);
+
+            /*
+             * Compiling this repository's own source: checked-in input, never
+             * user input, and compiled without ever being run. Suppression must
+             * sit on the reported line itself.
+             */
+            expect(() => new Script(processed, { filename })).not.toThrow(); // NOSONAR
+        });
+    });
+});
+
+function parseManifest(source, targetBrowser) {
+    return JSON.parse(stripComments(preprocessPreservingLines(source, targetBrowser)));
+}
 
 /** manifest.json keeps plain `//` comments outside the directives. */
 function stripComments(json) {


### PR DESCRIPTION
Closes #387.

## User-visible change

None — CI and test-tooling only. No extension code is touched.

## What changed

**`test` is one job instead of three.** Only the last of its four steps took `matrix.browser`; Vitest picks its target inside the tests via `targetBrowser`, so `npm install`, `npm run lint` and `npm test` were byte-identical in all three legs. The build step that did vary is browser-independent in practice — the only per-browser failure mode in `copy → string-replace → preprocess → zip` is an unbalanced `@if`/`@endif`, and `preprocess` scans every directive whatever `BROWSER` it is resolving. It now builds firefox, since the e2e job already builds chrome and does it through the `default` task, which never zips.

The job went from three legs to one that finishes in **13s**.

**The missing coverage moved into the unit suite**, where it runs in ~30 ms rather than three `npm install`s:

| check | why it is new |
| --- | --- |
| Parse the resolved manifest for all three targets, assert the keys each must keep | The Opera manifest had never been parsed anywhere in the repo |
| Compile every shipped script for every target, from the real `preprocess` output | Nothing had ever parsed the JS the build ships, and the rest of the suite only compiles the chrome target |
| Pin `options.html` against the real `preprocess` package | It is the only file using the `<!-- @if -->` form and the only one with an opera-specific branch, so that branch of the helper parser was pinned against nothing |

**Removed the dead `uglify` block** from `Gruntfile.js`. `grunt-contrib-uglify` is in neither `package.json` nor `loadNpmTasks`, so it had never run — it read as output validation that did not exist, which is why the gap above went unnoticed.

`test/preprocess.test.js` goes from 19 to 43 cases; the full suite from 303 to 327.

### Two follow-on fixes the quality gate forced

Editing the build step pulled it into SonarCloud's new-code window and surfaced three findings on it, all pre-existing:

- **S7636**, secrets expanded in a `run` block. The build now uses dummy credentials, exactly as the e2e build already does and for the same reason: `string-replace` substitutes whatever it is handed, so the real secrets prove nothing about a build that only has to demonstrate the pipeline runs. As a bonus the job now also runs on pull requests from forks.
- **S6505 / S8543**, `npx` fetching an unpinned package on demand and running its lifecycle scripts. Now invokes `./node_modules/.bin/grunt`, matching how the e2e job already invokes Playwright.

`secrets.FEEDLY_CLIENT_ID` / `FEEDLY_CLIENT_SECRET` are no longer referenced anywhere in `.github/`.

## ✅ Branch protection already updated

`master` required `test (chrome)`, `test (opera)` and `test (firefox)`, which this PR deletes forever. The required contexts have been changed to `test`, `e2e`, `Analyze (javascript)`, `SonarCloud Code Analysis`, each keeping its app-id pin. There were no other open PRs when this branch was cut, so nothing was stranded.

## Verification

`npm run lint`, `npm test` (327 pass) and the exact CI build command all clean locally; every check on this PR is green.

Each new check was confirmed to actually fail on a deliberate defect, then reverted:

- Moving the comma outside the `sidePanel` directive in `manifest.json` — the exact shape issue #387 shows the build zipping — fails `resolves into valid JSON for firefox`.
- A syntax error inside the `BROWSER='opera'` branch of `feedly.api.js` fails `for opera > compiles feedly.api.js`, and only that case.
- Writing an `options.html` directive with double quotes, a form the helper parser does not accept, fails all three parity cases for that file.

## Browsers tested

Not manually loaded — no extension code changed. The firefox package build was run locally and the e2e suite (Chromium) is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded validation across supported browsers, including Chrome, Opera, and Firefox.
  - Added coverage for HTML, JavaScript, and manifest processing.
  - Added checks confirming shipped scripts compile successfully and browser-specific manifests remain valid.
  - Added consistency checks for side-panel paths.

- **Chores**
  - Updated automated browser testing while retaining Chromium-based end-to-end coverage.
  - Removed obsolete build minification configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->