### PR TITLE
Make the article action buttons easier to hit

### DIFF
--- a/e2e/popup-render-feeds.spec.js
+++ b/e2e/popup-render-feeds.spec.js
@@ -93,6 +93,30 @@ test.describe("popup feed rendering", () => {
         await expect(article.locator(".content")).toContainText("The full body text");
     });
 
+    // Issue #47: the buttons used to be 14x14 and flush against each other.
+    test("gives the article actions a big enough hit target", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a")]);
+        await signIn({ abilitySaveFeeds: true });
+
+        const page = await popupPage();
+        const buttons = page.locator("#feed .item").first().locator(".article-menu > *");
+        await expect(buttons).toHaveCount(3);
+
+        const boxes = [];
+        for (const button of await buttons.all()) {
+            const box = await button.boundingBox();
+            expect(box.width).toBeGreaterThanOrEqual(24);
+            expect(box.height).toBeGreaterThanOrEqual(24);
+            boxes.push(box);
+        }
+
+        boxes.sort((a, b) => a.x - b.x);
+        for (let i = 1; i < boxes.length; i++) {
+            const gap = boxes[i].x - (boxes[i - 1].x + boxes[i - 1].width);
+            expect(gap).toBeGreaterThanOrEqual(4);
+        }
+    });
+
     test("renders category chips when the option is on", async ({ mockApi, signIn, popupPage }) => {
         mockApi.setStream(GLOBAL_ALL, [item("a")]);
         await signIn({ showCategories: true });

--- a/e2e/popup-render-feeds.spec.js
+++ b/e2e/popup-render-feeds.spec.js
@@ -113,7 +113,7 @@ test.describe("popup feed rendering", () => {
         boxes.sort((a, b) => a.x - b.x);
         for (let i = 1; i < boxes.length; i++) {
             const gap = boxes[i].x - (boxes[i - 1].x + boxes[i - 1].width);
-            expect(gap).toBeGreaterThanOrEqual(4);
+            expect(gap).toBeGreaterThanOrEqual(6);
         }
     });
 

--- a/src/styles/css/style.css
+++ b/src/styles/css/style.css
@@ -48,6 +48,7 @@
     --items-bg-color: #fff;
     --item-bg-color: #fff;
     --item-hover-bg-color: #f5f5f4;
+    --item-menu-hover-bg-color: rgba(0, 0, 0, 0.08);
     --item-not-last-border-bottom: 1px solid #d2d2d2;
     --item-title-color: #444444;
     --item-saved-glyphicon-color: rgb(108, 198, 85);
@@ -113,6 +114,7 @@
     --items-bg-color: var(--color-primary);
     --item-bg-color: var(--color-primary);
     --item-hover-bg-color: var(--color-primary-hover);
+    --item-menu-hover-bg-color: rgba(255, 255, 255, 0.12);
     --item-not-last-border-bottom: 1px solid var(--color-primary-3);
     --item-title-color: var(--color-secondary);
     --item-saved-glyphicon-color: var(--color-feedly-green);
@@ -176,6 +178,7 @@
     --items-bg-color: var(--color-primary);
     --item-bg-color: var(--color-primary);
     --item-hover-bg-color: var(--color-primary-hover);
+    --item-menu-hover-bg-color: rgba(255, 255, 255, 0.12);
     --item-not-last-border-bottom: 1px solid var(--color-primary-3);
     --item-title-color: var(--color-secondary);
     --item-saved-glyphicon-color: var(--color-feedly-green);
@@ -252,6 +255,7 @@ body {
 
 #feedly {
     flex: 0 1 auto;
+    position: relative;
     top: 0;
     right: 0;
     left: 0;
@@ -313,13 +317,20 @@ body {
 }
 
 #popup-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
+
     margin-bottom: 10px;
-    text-align: right;
-    white-space: nowrap;
 }
 
 #popup-actions > em {
-    padding: 3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    padding: 5px;
 
     cursor: pointer;
 
@@ -335,7 +346,7 @@ body {
 #popup-actions > em:hover > .arrow-up{
     display: inline-block;
     position: absolute;
-    top: 24px;
+    bottom: 0;
     right: 6px;
 
     width: 0;
@@ -364,13 +375,14 @@ body {
     font-family: sans-serif;
     font-weight: bold;
     line-height: 14px;
+    white-space: nowrap;
 }
 
 #popup-actions > em:hover > span {
     display: inline-block;
 
-    position: fixed;
-    top: 40px;
+    position: absolute;
+    top: 100%;
     right: 20px;
     z-index: 1;
 
@@ -457,6 +469,11 @@ body {
 }
 
 .item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    column-gap: 8px;
+
     padding: 3px 10px;
 
     /* Workaround for https://github.com/olsh/w-Notifier/issues/73#issuecomment-292728526 */
@@ -475,14 +492,10 @@ body {
     padding-bottom: 10px;
 }
 
-.article-title,
-.blog-title {
-    width: calc(100% - 45px);
-}
-
-.tabs .article-title,
-.tabs .blog-title {
-    width: calc(100% - 55px);
+/* The title and the action menu share the first row; everything else spans it. */
+.blog-title,
+.item .content {
+    grid-column: 1 / -1;
 }
 
 .title {
@@ -500,27 +513,29 @@ body {
 }
 
 .article-menu {
-    float: right;
+    display: flex;
+    gap: 6px;
 
-    vertical-align: middle;
     font-size: 12px;
 }
 
 .article-menu > * {
-    height: 14px;
-    width: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 
-    vertical-align: middle;
-    line-height: 14px;
+    height: 24px;
+    width: 24px;
+
+    border-radius: 4px;
 }
 
-.article-menu,
-.article-title {
-    display: inline-block;
+.article-menu > *:hover {
+    background-color: var(--item-menu-hover-bg-color);
 }
 
 .tabs .save-feed {
-    display: inline-block;
+    display: inline-flex;
 }
 
 .save-feed {


### PR DESCRIPTION
Closes #47.

## What changes

The bookmark, mark-as-read and expand buttons in each article row were 14x14 px boxes holding a 13 px glyph, with no space between them — they overlapped each other and left almost nothing to aim at. They are now **24x24 px with a 6 px gap** and a rounded hover pad. The header toolbar buttons get 5 px of padding instead of 3, and the same 6 px gap.

The issue asked for this as an *option*. It ships as the new default for everyone instead — a 14 px hit target isn't a preference worth preserving — so no new settings are added.

## How

The room came from replacing the hand-reserved gutter. The title and second line were sized `width: calc(100% - 45px)`, with a `.tabs` variant at 55px for when the bookmark button is visible, and `.article-menu` floated into the gap. Bigger buttons would have overflowed it.

`.item` is a CSS grid now, so the button column sizes itself; both magic numbers and the float are gone. **`src/popup.html` is untouched** — the four children keep their DOM order and are just placed, so no selector churn anywhere.

Two consequences worth calling out in review:

- **The header tooltip and its caret** were positioned against the viewport at hardcoded guesses at the header height (`top: 24px`, `top: 40px`). Those were already wrong whenever the saved-feeds slider made the header taller. They now resolve against `#feedly`, so they follow the header at either height and no longer depend on button size. The tooltip keeps its `white-space: nowrap`, which it used to inherit from `#popup-actions`.
- **`.tabs .save-feed`** moves to `inline-flex`; it outranks `.article-menu > *` and would otherwise leave the bookmark button uncentred whenever saved feeds are on.

`.content:after { clear: both }` is deliberately kept — it clears floated images inside sanitised feed content, not just the menu float.

## Testing

`npm run lint`, `npm test` (327 pass) and `npm run test:e2e` (52 pass) are all green, plus a Firefox `grunt build`.

Adds one Playwright assertion in `e2e/popup-render-feeds.spec.js` guarding the hit target and the spacing — the suite's first geometry check, and the thing this PR exists for.

Checked by hand in the built extension: light / dark / nord, saved feeds on and off (two vs three buttons), one- and two-line titles, an RTL title, an expanded article with a floated image, the category filter's hide/show round trip, and both header heights for the tooltip.

Verified visually in the built extension across all three themes; not re-checked by hand in Firefox, though CI builds that target.

## Not in scope

#96 and #115 stay open. The other design ideas we looked at — the second-line layout, roomier rows, the expanded pane's serif fallback, and the oversized category chips — are deliberately left out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved article action controls with larger hit areas and clearer spacing for easier interaction.

* **Style**
  * Refined popup and feed layouts for better alignment and consistency.
  * Positioned action controls and navigation arrows more clearly.
  * Updated tooltips to appear below their controls.
  * Added theme-specific hover colors for light, dark, and Nord themes.
  * Improved article menu spacing and control presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
