### PR TITLE
Stop the counter reset from greying the toolbar icon

### DIFF
--- a/e2e/badge-counter.spec.js
+++ b/e2e/badge-counter.spec.js
@@ -69,6 +69,133 @@ test.describe("toolbar badge", () => {
         }).toPass(RETRY);
     });
 
+    /*
+     * Issue #102. With "reset counter on click" the badge counts only what has arrived
+     * since the reset, so it cannot say whether anything is unread -- the icon has to
+     * follow the total instead.
+     *
+     * chrome.action has no getIcon, so setIcon is recorded from inside the worker. The
+     * patch and the cycle it observes share one evaluate() on purpose: the serviceWorker
+     * fixture re-acquires the worker on every call, so a patch left behind across calls
+     * would be silently dropped when MV3 recycles it.
+     */
+    function resetThenUpdate(serviceWorker) {
+        return serviceWorker.evaluate(async () => {
+            const paths = [];
+            const setIcon = chrome.action.setIcon.bind(chrome.action);
+            chrome.action.setIcon = (details) => {
+                paths.push(details.path["19"]);
+                return setIcon(details);
+            };
+            try {
+                await globalThis.resetCounter();
+                await globalThis.updateCounter();
+            } finally {
+                chrome.action.setIcon = setIcon;
+            }
+            return {
+                paths,
+                badge: await chrome.action.getBadgeText({}),
+                unreadCount: globalThis.appGlobal.lastKnownUnreadCount
+            };
+        });
+    }
+
+    const RESET_OPTIONS = { resetCounterOnClick: true, grayIconColorIfNoUnread: true };
+
+    /*
+     * Waits for the update cycle sign-in kicks off, so the requests it spends are not
+     * counted as the ones under test. The count is null until a cycle has finished, which
+     * makes it a reliable sentinel even when the badge stays empty throughout.
+     */
+    async function signInAndSettle(signIn, serviceWorker, options) {
+        await signIn(options);
+        await expect.poll(
+            () => serviceWorker.evaluate(() => globalThis.appGlobal.lastKnownUnreadCount),
+            { message: "the extension never finished an update cycle" }
+        ).not.toBeNull();
+    }
+
+    /** How many markers/counts requests `run` spends. */
+    async function countsSpentBy(mockApi, run) {
+        const before = mockApi.requestsTo("/v3/markers/counts").length;
+        await run();
+        return mockApi.requestsTo("/v3/markers/counts").length - before;
+    }
+
+    test("keeps the icon active after a reset while articles are still unread", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 42 });
+        mockApi.setUnreadCountsSinceReset({ [GLOBAL_ALL]: 0 });
+
+        await signInAndSettle(signIn, serviceWorker, RESET_OPTIONS);
+        const { paths, badge, unreadCount } = await resetThenUpdate(serviceWorker);
+
+        expect(badge).toBe("");
+        expect(paths.at(-1)).toBe("/images/icon.png");
+        expect(unreadCount).toBe(42);
+    });
+
+    test("greys the icon once everything really has been read", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 0 });
+        mockApi.setUnreadCountsSinceReset({ [GLOBAL_ALL]: 0 });
+
+        await signInAndSettle(signIn, serviceWorker, RESET_OPTIONS);
+        const { paths, unreadCount } = await resetThenUpdate(serviceWorker);
+
+        expect(paths.at(-1)).toBe("/images/icon_inactive.png");
+        expect(unreadCount).toBe(0);
+    });
+
+    test("counts only what arrived since the reset on the badge", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 42 });
+        mockApi.setUnreadCountsSinceReset({ [GLOBAL_ALL]: 3 });
+
+        await signInAndSettle(signIn, serviceWorker, RESET_OPTIONS);
+        const { paths, badge } = await resetThenUpdate(serviceWorker);
+
+        expect(badge).toBe("3");
+        expect(paths.at(-1)).toBe("/images/icon.png");
+    });
+
+    /*
+     * The second request is the whole cost of this fix, so pin both halves of the guard:
+     * it is spent only when the badge is empty because of a reset and the icon colour
+     * actually depends on the answer.
+     */
+    test("asks feedly for the total when the icon depends on it", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 42 });
+        mockApi.setUnreadCountsSinceReset({ [GLOBAL_ALL]: 0 });
+
+        await signInAndSettle(signIn, serviceWorker, RESET_OPTIONS);
+        const spent = await countsSpentBy(mockApi, () => resetThenUpdate(serviceWorker));
+
+        expect(spent).toBe(2);
+        // The narrowed request comes first, the one that answers for the icon last.
+        const counts = mockApi.requestsTo("/v3/markers/counts");
+        expect(counts.at(-2).query.newerThan).toBeDefined();
+        expect(counts.at(-1).query.newerThan).toBeUndefined();
+    });
+
+    test("spends no second request when the icon never greys", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 42 });
+        mockApi.setUnreadCountsSinceReset({ [GLOBAL_ALL]: 0 });
+
+        await signInAndSettle(signIn, serviceWorker, { resetCounterOnClick: true });
+        const spent = await countsSpentBy(mockApi, () => resetThenUpdate(serviceWorker));
+
+        expect(spent).toBe(1);
+    });
+
+    test("spends no second request while something new has arrived", async ({ mockApi, signIn, serviceWorker }) => {
+        mockApi.setUnreadCounts({ [GLOBAL_ALL]: 42 });
+        mockApi.setUnreadCountsSinceReset({ [GLOBAL_ALL]: 3 });
+
+        await signInAndSettle(signIn, serviceWorker, RESET_OPTIONS);
+        const spent = await countsSpentBy(mockApi, () => resetThenUpdate(serviceWorker));
+
+        expect(spent).toBe(1);
+    });
+
     test("recovers by refreshing the token after a 401", async ({ mockApi, signIn, serviceWorker }) => {
         mockApi.setUnreadCounts({ [GLOBAL_ALL]: 5 });
         mockApi.failNext("markers/counts", 401);

--- a/e2e/fixtures/feedly-server.js
+++ b/e2e/fixtures/feedly-server.js
@@ -33,6 +33,7 @@ class FeedlyMockServer {
         this.subscriptions = [];
         this.categories = [];
         this.unreadCounts = [];
+        this.unreadCountsSinceReset = null;
         /** Stream id (decoded) to the items it should return. */
         this.streams = new Map();
     }
@@ -61,6 +62,15 @@ class FeedlyMockServer {
 
     setUnreadCounts(counts) {
         this.unreadCounts = Object.entries(counts).map(([id, count]) => ({ id, count }));
+    }
+
+    /**
+     * Counts to answer a `markers/counts?newerThan=...` with, which is how the extension
+     * asks for what has arrived since the counter was last reset. Left unset, a narrowed
+     * request gets the totals back, exactly as before.
+     */
+    setUnreadCountsSinceReset(counts) {
+        this.unreadCountsSinceReset = Object.entries(counts).map(([id, count]) => ({ id, count }));
     }
 
     /**
@@ -184,7 +194,10 @@ class FeedlyMockServer {
         }
 
         if (path === "markers/counts") {
-            return this.send(response, 200, { unreadcounts: this.unreadCounts });
+            const counts = url.searchParams.has("newerThan") && this.unreadCountsSinceReset
+                ? this.unreadCountsSinceReset
+                : this.unreadCounts;
+            return this.send(response, 200, { unreadcounts: counts });
         }
 
         // Marking as read, and saving or unsaving an entry.

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -123,6 +123,13 @@ var appGlobal = {
     getUserSubscriptionsPromise: null,
     refreshAccessTokenPromise: null,
     rateLimitedUntil: 0,
+    /* The total number of unread articles, as opposed to the number on the badge. The two
+       differ once resetCounterOnClick is on: the badge counts what arrived since the reset,
+       while this is what the icon colour answers for (issue #102). null means nothing has
+       been counted yet, and the icon is then left alone rather than greyed on a guess.
+       Persisted, because the worker is recycled between the cycle that learns the count and
+       the click that acts on it. */
+    lastKnownUnreadCount: null,
     /* The statuses the token endpoint uses to say that the grant will never be accepted
        again: 400 invalid_grant for an expired or revoked refresh token, 401 and 403 for
        one that no longer belongs to this client. Anything else, 429 and 5xx included, is
@@ -766,8 +773,13 @@ async function filterByNewFeeds(feeds) {
     return newFeeds;
 }
 
+/* Blanks the badge and starts counting again from now. Only the number is reset: nothing
+   was read, so whether anything is unread has not changed and the icon is left exactly as
+   it is (issue #102). Deliberately not setBadgeCounter(0): this runs on the click that
+   woke the worker, so the total is often not in memory yet, and greying the icon on a zero
+   it does not have is the bug itself. */
 async function resetCounter(){
-    setBadgeCounter(0);
+    await browser.action.setBadgeText({ text: "" });
     await browser.storage.local.set({ lastCounterResetTime: new Date().getTime() });
 }
 
@@ -812,8 +824,15 @@ async function updateSavedFeeds() {
     }
 }
 
-/* Sets badge counter if unread feeds more than zero */
-function setBadgeCounter(unreadFeedsCount) {
+/* Sets badge counter if unread feeds more than zero.
+ * totalUnreadCount is what the icon follows, and defaults to the badge number for the
+ * callers that count everything. The two differ only under resetCounterOnClick, where the
+ * badge counts what arrived since the last reset. */
+function setBadgeCounter(unreadFeedsCount, totalUnreadCount) {
+    if (totalUnreadCount === undefined) {
+        totalUnreadCount = unreadFeedsCount;
+    }
+
     if (appGlobal.options.showCounter) {
         const unreadFeedsCountNumber = +unreadFeedsCount;
         if (unreadFeedsCountNumber > 999) {
@@ -825,11 +844,34 @@ function setBadgeCounter(unreadFeedsCount) {
         browser.action.setBadgeText({ text: ""});
     }
 
-    if (!unreadFeedsCount && appGlobal.options.grayIconColorIfNoUnread) {
+    setUnreadIcon(totalUnreadCount);
+}
+
+/* Green while anything is unread, gray when nothing is and the user asked for that.
+ * Deliberately not driven by the badge number: a counter reset blanks that while articles
+ * are still unread, and the icon has to keep saying so (issue #102). null means the total
+ * is not known, in which case the icon keeps whatever it was last told -- greying on a
+ * guess is the bug itself. */
+function setUnreadIcon(totalUnreadCount) {
+    if (totalUnreadCount === null || totalUnreadCount === undefined) {
+        return;
+    }
+
+    const unreadCount = +totalUnreadCount || 0;
+    rememberUnreadCount(unreadCount);
+
+    if (!unreadCount && appGlobal.options.grayIconColorIfNoUnread) {
         browser.action.setIcon({ path: appGlobal.icons.inactive });
     } else {
         browser.action.setIcon({ path: appGlobal.icons.default });
     }
+}
+
+/* Outlives the worker, so a click that wakes a fresh one still knows whether anything is
+ * unread. Fire and forget, the way the feed caches are written. */
+function rememberUnreadCount(unreadCount) {
+    appGlobal.lastKnownUnreadCount = unreadCount;
+    browser.storage.local.set({ lastKnownUnreadCount: unreadCount }).catch(function () {});
 }
 
 /* Runs feeds update and stores unread feeds in cache
@@ -843,11 +885,9 @@ async function updateCounter() {
     try {
         if (appGlobal.options.resetCounterOnClick) {
             const options = await browser.storage.local.get("lastCounterResetTime");
-            let parameters = null;
-            if (options.lastCounterResetTime) {
-                parameters = { newerThan: options.lastCounterResetTime };
-            }
-            await makeMarkersRequest(parameters);
+            await makeMarkersRequest(options.lastCounterResetTime
+                ? { newerThan: options.lastCounterResetTime }
+                : null);
         } else {
             await browser.storage.local.set({lastCounterResetTime: new Date(0).getTime()});
             await makeMarkersRequest();
@@ -863,6 +903,36 @@ async function updateCounter() {
 }
 
 async function makeMarkersRequest(parameters){
+    const unreadFeedsCount = await requestUnreadCount(parameters);
+
+    setBadgeCounter(unreadFeedsCount, await resolveTotalUnreadCount(unreadFeedsCount, parameters));
+}
+
+/* What the icon should answer for, given the number the badge is about to show. An
+ * un-narrowed count already is the total, and a narrowed count above zero already proves
+ * the total is above zero, so feedly is asked a second time only when the badge is empty
+ * because of a reset and the icon colour actually depends on the answer. Both options are
+ * off by default, so a default install never pays for this. */
+async function resolveTotalUnreadCount(unreadFeedsCount, parameters) {
+    if (!parameters?.newerThan || unreadFeedsCount > 0 || !appGlobal.options.grayIconColorIfNoUnread) {
+        return unreadFeedsCount;
+    }
+
+    try {
+        return await requestUnreadCount();
+    } catch (e) {
+        // Unknown, including a 429 that landed between the two requests. Reported as
+        // unknown rather than as zero, so the icon keeps the last colour it was given
+        // instead of greying over articles that are probably still unread -- and so the
+        // badge just counted stays, which updateCounter's catch would have thrown away.
+        console.info("Unable to load the total unread count.", e);
+        return null;
+    }
+}
+
+/* The number of unread articles feedly reports for the streams the user is watching.
+ * `parameters.newerThan` narrows it to what has arrived since the counter was reset. */
+async function requestUnreadCount(parameters){
     const response = await apiRequestWrapper("markers/counts", { parameters: parameters });
     const unreadCounts = response.unreadcounts || [];
     let unreadFeedsCount = 0;
@@ -905,7 +975,7 @@ async function makeMarkersRequest(parameters){
         }
     }
 
-    setBadgeCounter(unreadFeedsCount);
+    return unreadFeedsCount;
 }
 
 /* Runs feeds update and stores unread feeds in cache
@@ -1008,6 +1078,9 @@ function setInactiveStatus() {
     browser.action.setIcon({ path: appGlobal.icons.inactive });
     browser.action.setBadgeText({ text: ""});
     appGlobal.cachedFeeds = [];
+    // Signed out there is nothing unread to speak of, and a stale total must not keep the
+    // icon green for whoever signs in next.
+    rememberUnreadCount(0);
     appGlobal.isLoggedIn = false;
     stopSchedule();
 }
@@ -1245,11 +1318,21 @@ async function markAsRead(feedIds) {
         // Update storage with the modified cached feeds
         await browser.storage.local.set({ cachedFeeds: appGlobal.cachedFeeds }).catch(function () {});
 
+        /* The badge number and the icon answer different questions once the counter has
+           been reset: the badge may be blank, or abbreviated past parsing, while articles
+           are still unread. So the badge is only touched when its text is usable, while
+           the icon always follows the tracked total (issue #102). */
         let feedsCount = await browser.action.getBadgeText({});
         feedsCount = +feedsCount;
+        const remainingUnread = appGlobal.lastKnownUnreadCount === null
+            ? null
+            : Math.max(0, appGlobal.lastKnownUnreadCount - copyArray.length);
+
         if (feedsCount > 0) {
             feedsCount -= copyArray.length;
-            setBadgeCounter(feedsCount);
+            setBadgeCounter(feedsCount, remainingUnread);
+        } else {
+            setUnreadIcon(remainingUnread);
         }
         return true;
     } catch {
@@ -1515,12 +1598,18 @@ async function readOptions() {
     appGlobal.options.currentUiLanguage = browser.i18n.getUILanguage();
 
     // Preload cached feeds from local storage to serve immediately on popup open
-    const cache = await browser.storage.local.get(["cachedFeeds", "cachedSavedFeeds", "rateLimitedUntil"]).catch(function () { return {}; });
+    const cache = await browser.storage.local.get(["cachedFeeds", "cachedSavedFeeds", "rateLimitedUntil", "lastKnownUnreadCount"]).catch(function () { return {}; });
     appGlobal.cachedFeeds = Array.isArray(cache.cachedFeeds) ? cache.cachedFeeds : [];
     appGlobal.cachedSavedFeeds = Array.isArray(cache.cachedSavedFeeds) ? cache.cachedSavedFeeds : [];
 
     // The alarm wakes a fresh worker, so the cooldown has to come back from storage
     appGlobal.rateLimitedUntil = Number(cache.rateLimitedUntil) || 0;
+
+    // And so does the count the icon colour rests on, which a click can arrive before any
+    // update cycle has recomputed.
+    appGlobal.lastKnownUnreadCount = typeof cache.lastKnownUnreadCount === "number"
+        ? cache.lastKnownUnreadCount
+        : null;
 
     // If we have a token, treat as logged in until a request proves otherwise
     appGlobal.isLoggedIn = Boolean(appGlobal.options.accessToken);

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -833,8 +833,9 @@ function setBadgeCounter(unreadFeedsCount, totalUnreadCount) {
         totalUnreadCount = unreadFeedsCount;
     }
 
+    const unreadFeedsCountNumber = +unreadFeedsCount;
+
     if (appGlobal.options.showCounter) {
-        const unreadFeedsCountNumber = +unreadFeedsCount;
         if (unreadFeedsCountNumber > 999) {
             const thousands = Math.floor(unreadFeedsCountNumber / 1000);
             unreadFeedsCount = thousands + "k+";
@@ -844,31 +845,48 @@ function setBadgeCounter(unreadFeedsCount, totalUnreadCount) {
         browser.action.setBadgeText({ text: ""});
     }
 
-    setUnreadIcon(totalUnreadCount);
+    // A badge number above zero proves something is unread even when the exact total is
+    // not known, which is the whole of what the icon needs to stay green.
+    setUnreadIcon(totalUnreadCount, unreadFeedsCountNumber > 0);
 }
 
 /* Green while anything is unread, gray when nothing is and the user asked for that.
- * Deliberately not driven by the badge number: a counter reset blanks that while articles
- * are still unread, and the icon has to keep saying so (issue #102). null means the total
- * is not known, in which case the icon keeps whatever it was last told -- greying on a
- * guess is the bug itself. */
-function setUnreadIcon(totalUnreadCount) {
-    if (totalUnreadCount === null || totalUnreadCount === undefined) {
+ *
+ * Deliberately not driven by the badge number alone: a counter reset blanks that while
+ * articles are still unread, and the icon has to keep saying so (issue #102).
+ * `totalUnreadCount` is the exact total, or null when only a lower bound is available --
+ * the reset-relative case, where `atLeastOneUnread` can still turn the icon green without
+ * anything exact being remembered for markAsRead to decrement. With neither, the icon
+ * keeps whatever it was last told: greying on a guess is the bug this exists to avoid. */
+function setUnreadIcon(totalUnreadCount, atLeastOneUnread) {
+    const exactTotal = totalUnreadCount === null || totalUnreadCount === undefined
+        ? null
+        : +totalUnreadCount || 0;
+
+    rememberUnreadCount(exactTotal);
+
+    if (!appGlobal.options.grayIconColorIfNoUnread) {
+        browser.action.setIcon({ path: appGlobal.icons.default });
         return;
     }
 
-    const unreadCount = +totalUnreadCount || 0;
-    rememberUnreadCount(unreadCount);
-
-    if (!unreadCount && appGlobal.options.grayIconColorIfNoUnread) {
-        browser.action.setIcon({ path: appGlobal.icons.inactive });
-    } else {
-        browser.action.setIcon({ path: appGlobal.icons.default });
+    if (exactTotal === null) {
+        // Only a lower bound to go on. It can turn the icon green, but it can never grey
+        // it: not knowing of anything unread is not the same as knowing of nothing.
+        if (atLeastOneUnread) {
+            browser.action.setIcon({ path: appGlobal.icons.default });
+        }
+        return;
     }
+
+    browser.action.setIcon({
+        path: exactTotal > 0 ? appGlobal.icons.default : appGlobal.icons.inactive
+    });
 }
 
 /* Outlives the worker, so a click that wakes a fresh one still knows whether anything is
- * unread. Fire and forget, the way the feed caches are written. */
+ * unread. null is "not known", which markAsRead must not decrement as though it were a
+ * count. Fire and forget, the way the feed caches are written. */
 function rememberUnreadCount(unreadCount) {
     appGlobal.lastKnownUnreadCount = unreadCount;
     browser.storage.local.set({ lastKnownUnreadCount: unreadCount }).catch(function () {});
@@ -908,14 +926,22 @@ async function makeMarkersRequest(parameters){
     setBadgeCounter(unreadFeedsCount, await resolveTotalUnreadCount(unreadFeedsCount, parameters));
 }
 
-/* What the icon should answer for, given the number the badge is about to show. An
- * un-narrowed count already is the total, and a narrowed count above zero already proves
- * the total is above zero, so feedly is asked a second time only when the badge is empty
- * because of a reset and the icon colour actually depends on the answer. Both options are
- * off by default, so a default install never pays for this. */
+/* The exact unread total, or null when this cycle cannot know it.
+ *
+ * An un-narrowed count already is the total. A narrowed one never is -- it is a lower
+ * bound, and reporting it as a total would have markAsRead decrement it as one, greying
+ * the icon over the articles that were already unread before the reset. So feedly is asked
+ * a second time, but only when the answer is worth a request: a narrowed count above zero
+ * already proves the total is above zero, which is all the icon needs, and with greying off
+ * the colour does not depend on the total at all. Both options are off by default, so a
+ * default install never pays for this. */
 async function resolveTotalUnreadCount(unreadFeedsCount, parameters) {
-    if (!parameters?.newerThan || unreadFeedsCount > 0 || !appGlobal.options.grayIconColorIfNoUnread) {
+    if (!parameters?.newerThan) {
         return unreadFeedsCount;
+    }
+
+    if (unreadFeedsCount > 0 || !appGlobal.options.grayIconColorIfNoUnread) {
+        return null;
     }
 
     try {

--- a/test/core.counter.test.js
+++ b/test/core.counter.test.js
@@ -55,6 +55,51 @@ describe("setBadgeCounter", () => {
 
         expect(browser._calls.setIcon).toEqual([appGlobal.icons.default]);
     });
+
+    /*
+     * Issue #102: with resetCounterOnClick the badge counts only what arrived since the
+     * last reset, so it cannot say whether anything is unread. The icon follows the total
+     * that is passed alongside it.
+     */
+    it("colours the icon from the total rather than from the badge number", () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+
+        ctx.setBadgeCounter(0, 12);
+
+        expect(browser._calls.setBadgeText).toEqual([""]);
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.default]);
+        expect(appGlobal.lastKnownUnreadCount).toBe(12);
+    });
+
+    it("greys the icon once the total reaches zero, whatever the badge says", () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+
+        ctx.setBadgeCounter(3, 0);
+
+        expect(browser._calls.setBadgeText).toEqual(["3"]);
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.inactive]);
+    });
+
+    /* Greying on a total nobody has counted is the bug, so an unknown one leaves the icon
+       showing whatever it was last told. */
+    it("leaves the icon alone when the total is unknown", () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+
+        ctx.setBadgeCounter(5, null);
+
+        expect(browser._calls.setBadgeText).toEqual(["5"]);
+        expect(browser._calls.setIcon).toEqual([]);
+    });
+
+    /* The worker is recycled between the cycle that counts and the click that acts on the
+       count, so it cannot live in memory alone. */
+    it("persists the total it was given", async () => {
+        ctx.setBadgeCounter(3, 40);
+
+        expect(appGlobal.lastKnownUnreadCount).toBe(40);
+        const stored = await browser.storage.local.get("lastKnownUnreadCount");
+        expect(stored.lastKnownUnreadCount).toBe(40);
+    });
 });
 
 describe("makeMarkersRequest", () => {
@@ -213,6 +258,39 @@ describe("updateCounter", () => {
     let browser;
     let appGlobal;
 
+    const RESET_TIME = 1700000000000;
+
+    /*
+     * Answers markers/counts with `total`, or with `newer` when the request carries
+     * newerThan, and records the parameters of every call so the request economy is
+     * assertable.
+     */
+    function stubCounts({ total, newer, failTotal }) {
+        const requested = [];
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method, settings) => {
+                const parameters = settings?.parameters;
+                requested.push(parameters);
+                if (!parameters?.newerThan) {
+                    if (failTotal) {
+                        throw { status: 500 };
+                    }
+                    return { unreadcounts: [{ id: "user/u1/category/global.all", count: total }] };
+                }
+                return { unreadcounts: [{ id: "user/u1/category/global.all", count: newer }] };
+            }
+        };
+        return requested;
+    }
+
+    /** The configuration issue #102 is about: both options on, with a reset recorded. */
+    async function enableResetAndGreying() {
+        appGlobal.options.resetCounterOnClick = true;
+        appGlobal.options.grayIconColorIfNoUnread = true;
+        await browser.storage.local.set({ lastCounterResetTime: RESET_TIME });
+    }
+
     beforeEach(() => {
         ({ ctx, browser, appGlobal } = loadCore());
         appGlobal.options.feedlyUserId = "u1";
@@ -259,6 +337,130 @@ describe("updateCounter", () => {
 
         expect(browser._calls.setBadgeText).toContain("");
     });
+
+    /*
+     * Issue #102: the reset empties the badge, not the account. A second markers/counts
+     * request without newerThan is what tells the icon that articles are still unread.
+     */
+    it("keeps the icon active when nothing is new but articles remain unread", async () => {
+        await enableResetAndGreying();
+        const requested = stubCounts({ total: 12, newer: 0 });
+
+        await ctx.updateCounter();
+
+        expect(requested).toEqual([{ newerThan: RESET_TIME }, undefined]);
+        expect(browser._calls.setBadgeText.at(-1)).toBe("");
+        expect(browser._calls.setIcon.at(-1)).toEqual(appGlobal.icons.default);
+        expect(appGlobal.lastKnownUnreadCount).toBe(12);
+    });
+
+    it("greys the icon when the account really has nothing unread", async () => {
+        await enableResetAndGreying();
+        stubCounts({ total: 0, newer: 0 });
+
+        await ctx.updateCounter();
+
+        expect(browser._calls.setIcon.at(-1)).toEqual(appGlobal.icons.inactive);
+    });
+
+    /* Anything new is already proof that something is unread, so the total is not worth
+       a request. */
+    it("spends no second request while something new has arrived", async () => {
+        await enableResetAndGreying();
+        const requested = stubCounts({ total: 12, newer: 4 });
+
+        await ctx.updateCounter();
+
+        expect(requested).toEqual([{ newerThan: RESET_TIME }]);
+        expect(browser._calls.setBadgeText.at(-1)).toBe("4");
+        expect(browser._calls.setIcon.at(-1)).toEqual(appGlobal.icons.default);
+    });
+
+    it("spends no second request when the icon never greys", async () => {
+        appGlobal.options.resetCounterOnClick = true;
+        await browser.storage.local.set({ lastCounterResetTime: RESET_TIME });
+        const requested = stubCounts({ total: 12, newer: 0 });
+
+        await ctx.updateCounter();
+
+        expect(requested).toEqual([{ newerThan: RESET_TIME }]);
+        expect(browser._calls.setIcon.at(-1)).toEqual(appGlobal.icons.default);
+    });
+
+    /* The badge has just been counted correctly, so a failed total must not reach
+       updateCounter's catch and throw it away, nor grey the icon over articles that are
+       probably still unread. */
+    it("leaves the icon alone when the total request fails", async () => {
+        await enableResetAndGreying();
+        ctx.setBadgeCounter(9);
+        const iconCallsBefore = browser._calls.setIcon.length;
+        stubCounts({ newer: 0, failTotal: true });
+
+        await ctx.updateCounter();
+
+        expect(browser._calls.setBadgeText.at(-1)).toBe("");
+        expect(browser._calls.setIcon.length).toBe(iconCallsBefore);
+        expect(appGlobal.lastKnownUnreadCount).toBe(9);
+    });
+
+    /* A 429 on the second request still has to record the cooldown, and still must not
+       reach updateCounter's catch. */
+    it("records the cooldown when the total request is rate limited", async () => {
+        await enableResetAndGreying();
+        ctx.setBadgeCounter(9);
+        const iconCallsBefore = browser._calls.setIcon.length;
+        appGlobal.feedlyApiClient = {
+            accessToken: "token",
+            request: async (method, settings) => {
+                if (settings?.parameters?.newerThan) {
+                    return { unreadcounts: [{ id: "user/u1/category/global.all", count: 0 }] };
+                }
+                throw {
+                    status: 429,
+                    headers: { get: (name) => (name === "Retry-After" ? "600" : null) }
+                };
+            }
+        };
+
+        await ctx.updateCounter();
+
+        expect(appGlobal.rateLimitedUntil).toBeGreaterThan(Date.now());
+        expect(browser._calls.setIcon.length).toBe(iconCallsBefore);
+    });
+});
+
+describe("lastKnownUnreadCount", () => {
+    /* The icon's count has to survive the worker being recycled, the same way the rate
+       limit cooldown does. */
+    it("comes back from storage when the worker wakes", async () => {
+        const { ctx, appGlobal } = loadCore({
+            storage: {
+                sync: { accessToken: "token" },
+                local: { lastKnownUnreadCount: 12 }
+            }
+        });
+
+        await ctx.readOptions();
+
+        expect(appGlobal.lastKnownUnreadCount).toBe(12);
+    });
+
+    it("stays unknown when nothing has been counted yet", async () => {
+        const { ctx, appGlobal } = loadCore({ storage: { sync: { accessToken: "token" } } });
+
+        await ctx.readOptions();
+
+        expect(appGlobal.lastKnownUnreadCount).toBeNull();
+    });
+
+    it("is zeroed on sign out", () => {
+        const { ctx, appGlobal } = loadCore();
+        ctx.setBadgeCounter(12);
+
+        ctx.setInactiveStatus();
+
+        expect(appGlobal.lastKnownUnreadCount).toBe(0);
+    });
 });
 
 describe("resetCounter", () => {
@@ -270,5 +472,21 @@ describe("resetCounter", () => {
         expect(browser._calls.setBadgeText).toEqual([""]);
         const stored = await browser.storage.local.get("lastCounterResetTime");
         expect(stored.lastCounterResetTime).toBeGreaterThan(0);
+    });
+
+    /*
+     * Issue #102: the reset is what the popup sends while showing a list of unread
+     * articles, so greying the icon there is wrong by construction. It also runs on the
+     * click that woke the worker, where no total has been counted yet -- so it must not
+     * touch the icon at all.
+     */
+    it("does not touch the icon", async () => {
+        const { ctx, browser, appGlobal } = loadCore();
+        appGlobal.options.grayIconColorIfNoUnread = true;
+
+        await ctx.resetCounter();
+
+        expect(browser._calls.setBadgeText).toEqual([""]);
+        expect(browser._calls.setIcon).toEqual([]);
     });
 });

--- a/test/core.counter.test.js
+++ b/test/core.counter.test.js
@@ -82,13 +82,32 @@ describe("setBadgeCounter", () => {
 
     /* Greying on a total nobody has counted is the bug, so an unknown one leaves the icon
        showing whatever it was last told. */
-    it("leaves the icon alone when the total is unknown", () => {
+    it("leaves the icon alone when nothing at all is known", () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+
+        ctx.setBadgeCounter(0, null);
+
+        expect(browser._calls.setBadgeText).toEqual([""]);
+        expect(browser._calls.setIcon).toEqual([]);
+    });
+
+    /* A badge number is a lower bound on the total: it cannot say how much is unread, but
+       it does prove that something is. */
+    it("keeps the icon active on the badge number alone when the total is unknown", () => {
         appGlobal.options.grayIconColorIfNoUnread = true;
 
         ctx.setBadgeCounter(5, null);
 
         expect(browser._calls.setBadgeText).toEqual(["5"]);
-        expect(browser._calls.setIcon).toEqual([]);
+        expect(browser._calls.setIcon).toEqual([appGlobal.icons.default]);
+    });
+
+    /* markAsRead decrements the remembered total as an exact count, so a lower bound must
+       never be remembered as one. */
+    it("remembers nothing when the total is unknown", () => {
+        ctx.setBadgeCounter(5, null);
+
+        expect(appGlobal.lastKnownUnreadCount).toBeNull();
     });
 
     /* The worker is recycled between the cycle that counts and the click that acts on the
@@ -376,6 +395,35 @@ describe("updateCounter", () => {
         expect(browser._calls.setIcon.at(-1)).toEqual(appGlobal.icons.default);
     });
 
+    /*
+     * A narrowed count is a lower bound, not a total. Remembering it as one would have
+     * markAsRead decrement it to zero and grey the icon over the articles that were
+     * already unread before the reset -- issue #102 again, by a different route.
+     */
+    it("does not remember a narrowed count as the total", async () => {
+        await enableResetAndGreying();
+        stubCounts({ total: 42, newer: 3 });
+
+        await ctx.updateCounter();
+
+        expect(browser._calls.setBadgeText.at(-1)).toBe("3");
+        expect(appGlobal.lastKnownUnreadCount).toBeNull();
+    });
+
+    it("keeps the icon active when only the newly arrived articles are read", async () => {
+        await enableResetAndGreying();
+        // 42 unread overall, 3 of which arrived since the reset.
+        stubCounts({ total: 42, newer: 3 });
+        await ctx.updateCounter();
+
+        appGlobal.cachedFeeds = [{ id: "a" }, { id: "b" }, { id: "c" }];
+        appGlobal.feedlyApiClient = { accessToken: "token", request: async () => ({}) };
+        await ctx.markAsRead(["a", "b", "c"]);
+
+        expect(browser._calls.setBadgeText.at(-1)).toBe("");
+        expect(browser._calls.setIcon).not.toContain(appGlobal.icons.inactive);
+    });
+
     it("spends no second request when the icon never greys", async () => {
         appGlobal.options.resetCounterOnClick = true;
         await browser.storage.local.set({ lastCounterResetTime: RESET_TIME });
@@ -389,7 +437,8 @@ describe("updateCounter", () => {
 
     /* The badge has just been counted correctly, so a failed total must not reach
        updateCounter's catch and throw it away, nor grey the icon over articles that are
-       probably still unread. */
+       probably still unread. The previous total goes back to unknown rather than being
+       kept: it is a cycle old, and markAsRead would decrement it as though it were not. */
     it("leaves the icon alone when the total request fails", async () => {
         await enableResetAndGreying();
         ctx.setBadgeCounter(9);
@@ -400,7 +449,7 @@ describe("updateCounter", () => {
 
         expect(browser._calls.setBadgeText.at(-1)).toBe("");
         expect(browser._calls.setIcon.length).toBe(iconCallsBefore);
-        expect(appGlobal.lastKnownUnreadCount).toBe(9);
+        expect(appGlobal.lastKnownUnreadCount).toBeNull();
     });
 
     /* A 429 on the second request still has to record the cooldown, and still must not

--- a/test/core.misc.test.js
+++ b/test/core.misc.test.js
@@ -201,6 +201,53 @@ describe("markAsRead", () => {
         expect(browser._calls.setBadgeText.at(-1)).toBe("1k+");
     });
 
+    /*
+     * Issue #102: after a counter reset the badge is blank, so there is no number to
+     * decrement -- but reading the last unread article still has to gray the icon.
+     */
+    it("greys the icon when the last unread article is read after a reset", async () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+        appGlobal.feedlyApiClient = { accessToken: "token", request: async () => ({}) };
+        // The badge is blank after a reset while one article is still unread.
+        ctx.setBadgeCounter(0, 1);
+        const iconCallsBefore = browser._calls.setIcon.length;
+
+        await ctx.markAsRead(["a"]);
+
+        expect(browser._calls.setIcon.slice(iconCallsBefore)).toEqual([appGlobal.icons.inactive]);
+    });
+
+    it("keeps the icon active while unread articles remain after a reset", async () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+        appGlobal.feedlyApiClient = { accessToken: "token", request: async () => ({}) };
+        ctx.setBadgeCounter(0, 5);
+
+        await ctx.markAsRead(["a"]);
+
+        expect(browser._calls.setIcon.at(-1)).toEqual(appGlobal.icons.default);
+        expect(appGlobal.lastKnownUnreadCount).toBe(4);
+    });
+
+    it("never drives the remembered total below zero", async () => {
+        appGlobal.feedlyApiClient = { accessToken: "token", request: async () => ({}) };
+        ctx.setBadgeCounter(0, 1);
+
+        await ctx.markAsRead(["a", "b", "c"]);
+
+        expect(appGlobal.lastKnownUnreadCount).toBe(0);
+    });
+
+    /* A worker that has never counted must not grey the icon on the guess that zero
+       articles are left. */
+    it("leaves the icon alone when no total has been counted yet", async () => {
+        appGlobal.options.grayIconColorIfNoUnread = true;
+        appGlobal.feedlyApiClient = { accessToken: "token", request: async () => ({}) };
+
+        await ctx.markAsRead(["a"]);
+
+        expect(browser._calls.setIcon).toEqual([]);
+    });
+
     it("reports failure and keeps the cache when the request fails", async () => {
         appGlobal.feedlyApiClient = {
             accessToken: "token",


### PR DESCRIPTION
Fixes #102.

## The problem

With **"Reset counter when extension button clicked"** on, the badge counts only what has arrived since the reset. `setBadgeCounter` derived the icon colour from that same number, so with **"Gray icon color if no unread"** also on, the icon went grey the moment nothing new had arrived — with hundreds of articles still unread.

`resetCounter` made it worse by calling `setBadgeCounter(0)` directly, greying the icon at the exact moment the popup was showing a list of unread articles.

## The change

The badge number and the icon now answer separate questions. `setBadgeCounter` takes the total alongside the badge count, and the icon follows the total. It defaults to the badge number for every caller that counts everything, so nothing else changes.

- **`resetCounter`** blanks the badge and does not touch the icon. Nothing was read, so whether anything is unread has not changed. It also runs on the click that woke the worker, where no total is in memory yet — greying on a zero it does not have is the bug itself.
- **`updateCounter`** asks feedly a second time for the un-narrowed total only when the badge is empty *because of a reset* and the icon colour actually depends on the answer. A narrowed count above zero already proves the total is above zero, so the request is skipped; and both options are off by default, so a default install never spends it. `getUserSubscriptions()` is memoised, so it costs exactly one extra `markers/counts` even with filters on. A failed or rate limited second request reports the total as *unknown* rather than as zero, which keeps the badge that was just counted and leaves the icon alone.
- **`markAsRead`** now updates the icon even when the badge text is unusable — blank after a reset, or abbreviated to `"1k+"` — so reading the last unread article greys the icon immediately instead of a cycle later. The badge itself is still only touched when its text parses, so the known `"1k+"` decrement bug is unchanged and its pinned test still passes.
- The total is **persisted and restored in `readOptions`** beside the rate limit cooldown. The worker is recycled between the cycle that counts and the click that acts on the count; `null` ("nothing counted yet") leaves the icon alone rather than greying it on a guess.

No option, manifest, locale or options-page change — both existing options keep their meaning.

## API cost

Deliberately narrow, given #385. The extra `markers/counts` is spent only while `resetCounterOnClick && grayIconColorIfNoUnread` are both on *and* nothing has arrived since the reset. Three e2e specs pin exactly when it is and is not made.

## Testing

- `npm run lint` — clean
- `npm test` — 373 passed, 18 new. 13 of the new unit tests were confirmed to fail against the unmodified `core.js`.
- `npm run test:e2e:chromium` — 58 passed, 6 new badge specs. 5 of the 6 were confirmed to fail against the unmodified `core.js`.
- `npm run test:e2e:firefox` — not run locally; covered by CI, which runs the full `npm run test:e2e`.

The e2e mock can now answer a `newerThan` request with its own counts (`setUnreadCountsSinceReset`), which is what lets the badge and the icon be asserted apart. `chrome.action` has no `getIcon`, so the specs record `setIcon` from inside the worker, patching and observing within a single `evaluate()` so an MV3 recycle cannot drop the patch.

No UI change, so no screenshots. Not manually loaded in a browser — the behaviour is covered by the unit and chromium e2e suites above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Badge counts now correctly reflect unread items since the last reset.
  * The toolbar icon remains active while unread articles remain and turns grey when all articles are read.
  * Unread totals persist across background worker restarts and are restored after sign-in.
  * Reading articles now updates unread status without producing incorrect negative counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->