### PR TITLE
Group and reschedule Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,38 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    # Version updates already wait out a 3-day cooldown by default; 7 buys a
+    # wider window for a compromised release to be yanked before it
+    # auto-merges unattended and ships to the stores. Security updates ignore
+    # cooldown entirely, so real CVE fixes are not delayed by this.
+    cooldown:
+      default-days: 7
+    groups:
+      # minor and patch only, so a group can never contain a major: the
+      # `update-type` gate in automerge.yml reports the highest bump in the
+      # PR, and majors stay ungrouped and wait for a human, as they do now.
+      #
+      # Runtime and tooling stay apart because a production bump changes what
+      # reaches the stores, and a twelve-package grouped commit is a bad thing
+      # to bisect when the extension misbehaves.
+      runtime:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      dev-tooling:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
 
+  # Only the pins that name an exact version see minor and patch releases at
+  # all: a `@v7`-style tag moves on its own and surfaces here only when the
+  # major changes. So this group is mostly codeql-action and the two SHA pins.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,16 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # google-github-actions/auth handles CHROME_SERVICE_ACCOUNT_KEY and is a SHA
+    # pin, so a minor bump moving that SHA auto-merges: it waits out the same
+    # seven days as npm. codeql-action is excluded because the cooldown filter
+    # only inspects the newest release, so an action shipping faster than the
+    # window stops updating altogether (dependabot-core#13691, #14579) -- and
+    # its releases are a median of about five days apart. It keeps the
+    # three-day default, which its cadence clears.
+    cooldown:
+      default-days: 7
+      exclude: ["github/codeql-action*"]
     groups:
       actions:
         update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,11 +37,16 @@ updates:
       day: "monday"
     # google-github-actions/auth handles CHROME_SERVICE_ACCOUNT_KEY and is a SHA
     # pin, so a minor bump moving that SHA auto-merges: it waits out the same
-    # seven days as npm. codeql-action is excluded because the cooldown filter
-    # only inspects the newest release, so an action shipping faster than the
-    # window stops updating altogether (dependabot-core#13691, #14579) -- and
-    # its releases are a median of about five days apart. It keeps the
-    # three-day default, which its cadence clears.
+    # seven days as npm.
+    #
+    # codeql-action is exempt from the wait entirely -- `exclude` means no
+    # cooldown at all, not a shorter one. The filter only inspects the newest
+    # release, so an action shipping faster than the window stops updating
+    # altogether (dependabot-core#13691, #14579), and codeql-action releases a
+    # median of about five days apart would spend most Mondays inside a
+    # seven-day window. Keeping the scanner current is worth more than the
+    # wait: it is first-party, and codeql-analysis.yml holds no store
+    # credentials.
     cooldown:
       default-days: 7
       exclude: ["github/codeql-action*"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ The line between the two is narrower than "is it sensitive": a value is a variab
 
 ## Commit & Pull Request Guidelines
 
-Recent history uses short, imperative subjects such as `Sanitize feed content in all browsers`; dependency updates use `Bump <package> from <old> to <new> (#123)`. Keep commits focused and avoid signatures, attribution footers, or generated-by notices. Pull requests should explain the user-visible change, link relevant issues, list browsers manually tested, and include screenshots for UI changes. Confirm lint, the unit suite, and a clean browser-specific build before requesting review.
+Recent history uses short, imperative subjects such as `Sanitize feed content in all browsers`; dependency updates use `Bump <package> from <old> to <new> (#123)`, or `Bump the <group> group with <n> updates (#123)` where Dependabot batched several into one pull request. Keep commits focused and avoid signatures, attribution footers, or generated-by notices. Pull requests should explain the user-visible change, link relevant issues, list browsers manually tested, and include screenshots for UI changes. Confirm lint, the unit suite, and a clean browser-specific build before requesting review.
 
 ## Security & Configuration
 


### PR DESCRIPTION
## What changes

Dependabot's config had gone untouched since 2023 — an ecosystem and a monthly interval each for npm and github-actions, nothing else. This groups updates, moves to a weekly schedule, raises the PR limit and sets an explicit cooldown.

**No user-visible change**; this is repository automation only. `automerge.yml` is deliberately left alone.

## Why

- **Grouping.** Updates arrived as a burst on the 1st — 5 PRs on 2026-09-01, 5 on 2026-05-01, 4 on 2026-04-01 and 2026-06-01. Each runs `test` and `e2e` in full, then triggers the workflow again on push to master when it merges.
- **The PR limit was binding.** 5 is the `open-pull-requests-limit` default, and those two months hit exactly 5 — so updates were being deferred, not just batched. Raised to 10.
- **Monthly latency.** `actions/upload-artifact` landed on 2026-09-07 already three majors behind (`v4` against `v7.0.1`) and would not have been looked at until October.

## Why this is safe with automerge

`automerge.yml` gates on `update-type != 'version-update:semver-major'`, and [`fetch-metadata`](https://github.com/dependabot/fetch-metadata) reports "the highest semver change being made by this PR". Every group here is scoped to `minor`/`patch`, so a group can never *contain* a major — the gate always resolves to non-major for grouped PRs, and majors keep arriving individually for human review. That is why the workflow needs no change.

Groups default to `applies-to: version-updates`, so security updates stay individual and immediate. Cooldown likewise applies to version updates only, so no CVE fix is delayed by the 7 days — version updates already wait out 3 days by default, and 7 widens the window for a compromised release to be yanked before it auto-merges unattended and ships to the stores.

Runtime and tooling are separate groups because a production bump changes what reaches the stores, and a twelve-package grouped commit is a bad thing to bisect when the extension misbehaves.

## Also

`AGENTS.md` picks up the grouped commit-subject form, since `Bump the <group> group with <n> updates` departs from the convention documented there.

No `ignore` entry is needed for `fastify/github-action-merge-dependabot` — #383 removed it from the workflows, so Dependabot drops it on its own.

## Testing

Config validated as YAML and against the [options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference). No source files touched, so no browser testing or screenshots apply; `test` and `e2e` should be unaffected. The real proof is the next Monday run — expect at most one `runtime`, one `dev-tooling` and one `actions` PR instead of five loose ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dependabot updates now run weekly on Mondays for npm packages and GitHub Actions.
  * npm updates are grouped by runtime and development tooling, with pull request limits and cooldowns applied.
  * GitHub Actions updates are grouped to streamline minor and patch updates, with selected updates excluded.

* **Documentation**
  * Updated commit guidance to reflect the format used for grouped dependency updates, including batched update counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->