### PR TITLE
Restore the popup width option on Firefox

### DIFF
--- a/e2e/firefox/popup-render.spec.js
+++ b/e2e/firefox/popup-render.spec.js
@@ -30,6 +30,19 @@ test.describe("firefox popup", () => {
         }));
     }
 
+    /* Opens one of the two documents and waits for it to have rendered. Every step here crosses
+       geckodriver rather than a devtools socket, and the event page answers slower than a service
+       worker, so the render is polled for rather than checked once. */
+    async function openRendered(openExtensionPage, url, expected = 1) {
+        const page = await openExtensionPage(url);
+
+        await expect(async () => {
+            expect(await page.count("#feed .item")).toBe(expected);
+        }).toPass(RETRY);
+
+        return page;
+    }
+
     test("shows the login prompt when signed out", async ({ mockApi, openExtensionPage }) => {
         mockApi.setStream(GLOBAL_ALL, []);
 
@@ -45,11 +58,7 @@ test.describe("firefox popup", () => {
         mockApi.setStream(GLOBAL_ALL, [item("a"), item("b"), item("c")]);
         await signIn();
 
-        const page = await openExtensionPage("popup.html");
-
-        await expect(async () => {
-            expect(await page.count("#feed .item")).toBe(3);
-        }).toPass(RETRY);
+        const page = await openRendered(openExtensionPage, "popup.html", 3);
 
         const titles = await page.evaluate(() =>
             [...document.querySelectorAll("#feed .title")].map(node => node.textContent.trim()));
@@ -60,11 +69,8 @@ test.describe("firefox popup", () => {
         mockApi.setStream(GLOBAL_ALL, [item("a")]);
         await signIn();
 
-        const page = await openExtensionPage("popup.html");
+        const page = await openRendered(openExtensionPage, "popup.html");
 
-        await expect(async () => {
-            expect(await page.count("#feed .item")).toBe(1);
-        }).toPass(RETRY);
         expect(await layout(page)).toEqual({ body: "", content: "" });
     });
 
@@ -78,11 +84,7 @@ test.describe("firefox popup", () => {
         mockApi.setStream(GLOBAL_ALL, [item("a", { title: LONG_TITLE })]);
         await signIn({ popupWidth: 420 });
 
-        const page = await openExtensionPage("popup.html");
-
-        await expect(async () => {
-            expect(await page.count("#feed .item")).toBe(1);
-        }).toPass(RETRY);
+        const page = await openRendered(openExtensionPage, "popup.html");
 
         const measured = await page.evaluate(() => ({
             feed: document.getElementById("feed").style.width,
@@ -98,11 +100,8 @@ test.describe("firefox popup", () => {
         mockApi.setStream(GLOBAL_ALL, [item("a")]);
         await signIn();
 
-        const page = await openExtensionPage("popup.html?panel=1");
+        const page = await openRendered(openExtensionPage, "popup.html?panel=1");
 
-        await expect(async () => {
-            expect(await page.count("#feed .item")).toBe(1);
-        }).toPass(RETRY);
         // The browser sizes the sidebar, so the popup's fixed width has to give way to it.
         expect(await layout(page)).toEqual({ body: "100%", content: "100%" });
     });
@@ -116,11 +115,7 @@ test.describe("firefox popup", () => {
         await signIn();
 
         const panel = await openExtensionPage("popup.html?panel=1");
-        const popup = await openExtensionPage("popup.html");
-
-        await expect(async () => {
-            expect(await popup.count("#feed .item")).toBe(1);
-        }).toPass(RETRY);
+        const popup = await openRendered(openExtensionPage, "popup.html");
 
         expect(await panel.evaluate(() => document.body.style.width)).toBe("100%");
         expect(await popup.evaluate(() => document.body.style.width)).toBe("");

--- a/e2e/firefox/popup-render.spec.js
+++ b/e2e/firefox/popup-render.spec.js
@@ -12,6 +12,10 @@ const { item, SUBSCRIPTIONS, GLOBAL_ALL } = require("../fixtures/feed-items");
  * makes this the one place it can be tested for real.
  */
 test.describe("firefox popup", () => {
+    /* Long enough that a popup sizing itself to its content is unmistakably wider than one
+       held at the configured width. */
+    const LONG_TITLE = "An article headline long enough that an unpinned popup would stretch well past the width the user configured";
+
     test.beforeEach(async ({ mockApi }) => {
         mockApi.subscriptions = SUBSCRIPTIONS;
     });
@@ -62,6 +66,32 @@ test.describe("firefox popup", () => {
             expect(await page.count("#feed .item")).toBe(1);
         }).toPass(RETRY);
         expect(await layout(page)).toEqual({ body: "", content: "" });
+    });
+
+    /* The width that setPopupWidth() pins onto #feed. #popup-body shrink-wraps, so that pin is
+       the only thing between the popup and the width of its longest article title -- and firefox
+       is where it came undone. getState used to hand the popup appGlobal.options itself, whose
+       popupWidth is an accessor property, and the clone behind runtime.sendMessage shows own data
+       properties only. The popup read undefined, jQuery took .width(undefined) for a getter and
+       wrote nothing, and a filled popup grew to roughly twice the width of an empty one. */
+    test("pins the popup to the configured width", async ({ mockApi, signIn, openExtensionPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a", { title: LONG_TITLE })]);
+        await signIn({ popupWidth: 420 });
+
+        const page = await openExtensionPage("popup.html");
+
+        await expect(async () => {
+            expect(await page.count("#feed .item")).toBe(1);
+        }).toPass(RETRY);
+
+        const measured = await page.evaluate(() => ({
+            feed: document.getElementById("feed").style.width,
+            body: Math.round(document.body.getBoundingClientRect().width)
+        }));
+
+        expect(measured.feed).toBe("420px");
+        // Unpinned, the shrink-wrapped body follows the title instead and runs far past this.
+        expect(measured.body).toBeLessThan(500);
     });
 
     test("takes the sidebar layout with the panel marker", async ({ mockApi, signIn, openExtensionPage }) => {

--- a/e2e/popup-render-feeds.spec.js
+++ b/e2e/popup-render-feeds.spec.js
@@ -2,6 +2,10 @@ const { test, expect } = require("./fixtures/extension");
 const { item, SUBSCRIPTIONS, GLOBAL_ALL } = require("./fixtures/feed-items");
 
 test.describe("popup feed rendering", () => {
+    /* Long enough that a popup sizing itself to its content is unmistakably wider than one
+       held at the configured width. */
+    const LONG_TITLE = "An article headline long enough that an unpinned popup would stretch well past the width the user configured";
+
     test.beforeEach(async ({ mockApi }) => {
         mockApi.subscriptions = SUBSCRIPTIONS;
     });
@@ -115,6 +119,24 @@ test.describe("popup feed rendering", () => {
             const gap = boxes[i].x - (boxes[i - 1].x + boxes[i - 1].width);
             expect(gap).toBeGreaterThanOrEqual(6);
         }
+    });
+
+    /* Same pin as the firefox suite asserts, for the same reason: setPopupWidth() writing a width
+       onto #feed is all that keeps the shrink-wrapped body off the longest article title. */
+    test("pins the popup to the configured width", async ({ mockApi, signIn, popupPage }) => {
+        mockApi.setStream(GLOBAL_ALL, [item("a", { title: LONG_TITLE })]);
+        await signIn({ popupWidth: 420 });
+
+        const page = await popupPage();
+        await expect(page.locator("#feed .item")).toHaveCount(1);
+
+        const measured = await page.evaluate(() => ({
+            feed: document.getElementById("feed").style.width,
+            body: Math.round(document.body.getBoundingClientRect().width)
+        }));
+
+        expect(measured.feed).toBe("420px");
+        expect(measured.body).toBeLessThan(500);
     });
 
     test("renders category chips when the option is on", async ({ mockApi, signIn, popupPage }) => {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -39,6 +39,18 @@ async function restoreFeedTabId() {
 // Kick off initialization eagerly on worker boot
 ensureInitialized();
 
+/* A plain snapshot of the options for a UI page.
+
+   updateInterval, popupWidth and expandedPopupWidth are accessor properties on
+   appGlobal.options, and runtime.sendMessage clones whatever it is handed. Firefox clones
+   through an Xray wrapper, which shows own data properties only, so the getters were dropped
+   on the way out and the popup read the two widths back as undefined -- whereupon jQuery took
+   .width(undefined) for a getter and silently left the popup to shrink-wrap its longest
+   article title. Spreading resolves them here, in the realm that still has them. */
+function serializeOptions() {
+    return { ...appGlobal.options };
+}
+
 // Route messages from UI pages to background functions
 browser.runtime.onMessage.addListener(async (message, sender) => {
     try {
@@ -47,12 +59,12 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
         switch (message && message.type) {
             case "getState":
                 return {
-                    options: appGlobal.options,
+                    options: serializeOptions(),
                     environment: appGlobal.environment,
                     isLoggedIn: appGlobal.isLoggedIn || false
                 };
             case "getOptions":
-                return { options: appGlobal.options };
+                return { options: serializeOptions() };
             case "getFeeds":
                 return await getFeeds(Boolean(message.forceUpdate));
             case "getSavedFeeds":

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -12,6 +12,8 @@ const bg = {
 };
 
 let options = {};
+//The lower bound core.js clamps popupWidth and expandedPopupWidth to.
+const minPopupWidth = 380;
 let environment = { os: "" };
 
 /* The layout for the page rendered as a panel rather than as the toolbar popup. Chromium's
@@ -572,9 +574,15 @@ function setLastVisibleItems() {
 
 function setPopupWidth(expanded) {
     if (! popupGlobal.isSidebar) {
-        const width = expanded
+        const configured = expanded
             ? options.expandedPopupWidth
             : options.popupWidth;
+
+        //jQuery reads .width(undefined) as a getter and drops a NaN, either of which would set
+        //no width at all and leave the popup to shrink-wrap its longest article title. Falling
+        //back to the same floor core.js clamps to keeps that from being silent.
+        const requested = Number(configured);
+        const width = Number.isFinite(requested) && requested > 0 ? requested : minPopupWidth;
 
         $("#feed, #feed-saved, #feed-empty, #loading").width(width);
     }

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -44,6 +44,33 @@ describe("background message router", () => {
         expect(result.options.maxNumberOfFeeds).toBe(20);
     });
 
+    /* appGlobal.options carries updateInterval, popupWidth and expandedPopupWidth as accessor
+       properties. runtime.sendMessage clones the payload, and firefox clones through an Xray
+       wrapper that shows own data properties only, so handing out appGlobal.options itself
+       dropped all three -- the popup got _popupWidth but not popupWidth, and applied no width
+       at all. Both routes have to hand over resolved values. */
+    it.each(["getState", "getOptions"])("resolves the computed options for %s", async (type) => {
+        const { options } = await onMessage({ type });
+
+        for (const name of ["updateInterval", "popupWidth", "expandedPopupWidth"]) {
+            const descriptor = Object.getOwnPropertyDescriptor(options, name);
+
+            expect(descriptor).toBeDefined();
+            expect(descriptor.get).toBeUndefined();
+            expect(typeof descriptor.value).toBe("number");
+        }
+    });
+
+    it("clamps the popup widths it hands out", async () => {
+        appGlobal.options.popupWidth = 100;
+        appGlobal.options.expandedPopupWidth = 5000;
+
+        const { options } = await onMessage({ type: "getState" });
+
+        expect(options.popupWidth).toBe(380);
+        expect(options.expandedPopupWidth).toBe(800);
+    });
+
     it("rejects an unknown message type", async () => {
         await expect(onMessage({ type: "nonsense" })).resolves.toEqual({
             error: "Unknown message type"

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -15,7 +15,8 @@ const POPUP_EXPORTS = [
     "popupGlobal",
     "renderFromCache",
     "markAsRead",
-    "openFeedlyTab"
+    "openFeedlyTab",
+    "setPopupWidth"
 ];
 
 async function loadPopup(overrides = {}) {
@@ -361,5 +362,66 @@ describe("closing the popup", () => {
         release();
         await opening;
         expect(events).toEqual(["send:openFeedlyTab", "close"]);
+    });
+});
+
+/* The popup has no width of its own: #popup-body shrink-wraps, and setPopupWidth is the only
+   thing that pins #feed. When it writes nothing the popup sizes itself to its longest article
+   title instead, which is what a firefox user saw as a filled popup twice the width of an empty
+   one. jQuery is complicit -- .width(undefined) is its getter and .width(NaN) is dropped, so a
+   missing option failed silently. */
+describe("setPopupWidth", () => {
+    let popup;
+    let $;
+
+    const widths = () => ["#feed", "#feed-saved", "#feed-empty", "#loading"]
+        .map(selector => $(selector)[0].style.width);
+
+    beforeEach(async () => {
+        ({ page: popup, $ } = await loadPopup());
+    });
+
+    it("applies the configured width to every feed container", () => {
+        popup.options.popupWidth = 500;
+
+        popup.setPopupWidth(false);
+
+        expect(widths()).toEqual(["500px", "500px", "500px", "500px"]);
+    });
+
+    it("applies the expanded width once an article is open", () => {
+        popup.options.popupWidth = 500;
+        popup.options.expandedPopupWidth = 700;
+
+        popup.setPopupWidth(true);
+
+        expect(widths()).toEqual(["700px", "700px", "700px", "700px"]);
+    });
+
+    /* getState used to hand over appGlobal.options itself, whose widths are accessor properties;
+       the firefox clone dropped them and the popup got undefined. Fixed at the source in
+       background.js, but a width has to be written whatever arrives here. */
+    it.each([
+        ["undefined", undefined],
+        ["NaN", Number("nonsense")],
+        ["an empty string", ""],
+        ["zero", 0]
+    ])("falls back to the minimum when the option is %s", (label, value) => {
+        popup.options.popupWidth = value;
+
+        popup.setPopupWidth(false);
+
+        expect(widths()).toEqual(["380px", "380px", "380px", "380px"]);
+    });
+
+    /* The sidebar and the side panel are sized by the browser, and applySidebarLayout() has
+       already swapped the fixed widths for percentages. */
+    it("leaves the sidebar to size itself", () => {
+        popup.popupGlobal.isSidebar = true;
+        popup.options.popupWidth = 500;
+
+        popup.setPopupWidth(false);
+
+        expect(widths()).toEqual(["", "", "", ""]);
     });
 });


### PR DESCRIPTION
## The report

> since a few hours ago my filled popup is almost as twice as wide as my empty popup, and I can't seem to be able to shrink it (both popup width and expanded popup width are at 380).

Firefox 155, Windows 11. Reproduced.

## What is happening

`appGlobal.options` exposes `updateInterval`, `popupWidth` and `expandedPopupWidth` as **accessor properties** over the `_`-prefixed fields backing them. The message router handed `appGlobal.options` itself to `getState` and `getOptions`, and `runtime.sendMessage` clones whatever it is given.

Firefox clones through an Xray wrapper, and [Xray vision shows own data properties only](https://firefox-source-docs.mozilla.org/dom/scriptSecurity/xray_vision.html) — *"functions and accessor properties of the object are not visible in the Xray"*. All three getters were dropped in transit, so the popup received `_popupWidth: 380` but `popupWidth: undefined`. Chromium [serializes messages as JSON](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities), which resolves getters, so only Firefox saw it.

`setPopupWidth` then called `$(...).width(undefined)` — jQuery's **getter**. It set nothing, threw nothing and logged nothing, leaving `#feed` with no width. `#popup-body` is `inline-flex`, so with nothing pinning it the popup sized itself to its content:

* **empty popup** → `#feed-empty` is short, so it landed on `#popup-content { min-width: 380px }` and looked correct;
* **filled popup** → grew to the width of its longest article title, up to the [800px ceiling Firefox clamps a popup to](https://bugzilla.mozilla.org/show_bug.cgi?id=1404626).

Hence "almost twice as wide", and hence no setting could shrink it.

## Why it only surfaced now

The widths have been lost since the MV3 rewrite, but it was invisible: the old `.article-title, .blog-title { width: calc(100% - 45px) }` contributes ~0 to Gecko's intrinsic width, so an unpinned popup collapsed onto that same 380px minimum and looked right by accident. #389 replaced it with `grid-template-columns: minmax(0, 1fr) auto`, whose title track propagates the full max-content title width instead.

Measured against the real rule set, three articles, at Firefox's 800px ceiling:

| | `#feed` pinned to 380px | `#feed` unpinned |
| --- | --- | --- |
| pre-#389 CSS | 380px | 454px |
| 3.3.0 CSS | 380px | **519px**, and it grows with title length |

Firefox users met both changes at once — AMO went straight from 2.29.1 (July 2023) to 3.3.0.

## The change

* `serializeOptions()` in `background.js` resolves the getters in the background's own realm, so what crosses the wire is plain data no clone can strip. Both `getState` and `getOptions` use it.
* `setPopupWidth` falls back to the same 380 floor `core.js` clamps to, so a width is always written rather than silently skipped.

## Tests

* `test/background.test.js` — both message routes hand over `updateInterval`, `popupWidth` and `expandedPopupWidth` as own **data** properties, and the values are clamped. Fails on `master`.
* `test/popup.test.js` — `setPopupWidth` had no coverage at all; it now pins the configured width, the expanded width, the fallback for `undefined`/`NaN`/`""`/`0`, and the sidebar opt-out. The fallback cases fail without the `popup.js` change.
* `e2e/firefox/popup-render.spec.js` and `e2e/popup-render-feeds.spec.js` — with a deliberately long headline, `#feed` keeps the configured width and the shrink-wrapped body does not follow the title. The Firefox one is the case that reproduces the report.

## Browsers tested

Chromium and Firefox, through `npm run test:e2e`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed popup sizing so configured widths apply consistently, including expanded article views.
  - Long article titles no longer force the popup beyond its configured width.
  - Invalid, missing, or zero-width settings now fall back to a safe minimum width.
  - Popup width and related settings are now handled reliably in Firefox.
  - Sidebar layouts remain unaffected by popup width settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->